### PR TITLE
Get CI consistently green

### DIFF
--- a/lib/annotate_rb/cli.rb
+++ b/lib/annotate_rb/cli.rb
@@ -12,7 +12,6 @@ module AnnotateRb
     HELP_MAPPING = %w(-h -? --help).to_set
     VERSION_MAPPING = %w(-v --version).to_set
 
-
     def run(args = ARGV)
       _original_argv = ARGV.dup
 

--- a/spec/lib/annotate/annotate_models_annotate_model_file_spec.rb
+++ b/spec/lib/annotate/annotate_models_annotate_model_file_spec.rb
@@ -6,8 +6,6 @@ require 'files'
 require 'tmpdir'
 
 RSpec.describe AnnotateModels do
-  include AnnotateTestConstants
-
   describe '.annotate_model_file' do
     before do
       class Foo < ActiveRecord::Base; end

--- a/spec/lib/annotate/annotate_models_annotate_model_file_spec.rb
+++ b/spec/lib/annotate/annotate_models_annotate_model_file_spec.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require_relative '../../spec_helper'
 require 'annotate/annotate_models'
 require 'annotate/active_record_patch'
 require 'active_support/core_ext/string'

--- a/spec/lib/annotate/annotate_models_annotate_model_file_spec.rb
+++ b/spec/lib/annotate/annotate_models_annotate_model_file_spec.rb
@@ -6,19 +6,7 @@ require 'files'
 require 'tmpdir'
 
 RSpec.describe AnnotateModels do
-  MAGIC_COMMENTS = [
-    '# encoding: UTF-8',
-    '# coding: UTF-8',
-    '# -*- coding: UTF-8 -*-',
-    '#encoding: utf-8',
-    '# encoding: utf-8',
-    '# -*- encoding : utf-8 -*-',
-    "# encoding: utf-8\n# frozen_string_literal: true",
-    "# frozen_string_literal: true\n# encoding: utf-8",
-    '# frozen_string_literal: true',
-    '#frozen_string_literal: false',
-    '# -*- frozen_string_literal : true -*-'
-  ].freeze
+  include AnnotateTestConstants
 
   describe '.annotate_model_file' do
     before do

--- a/spec/lib/annotate/annotate_models_annotating_a_file_frozen_spec.rb
+++ b/spec/lib/annotate/annotate_models_annotating_a_file_frozen_spec.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require_relative '../../spec_helper'
 require 'annotate/annotate_models'
 require 'annotate/active_record_patch'
 require 'active_support/core_ext/string'

--- a/spec/lib/annotate/annotate_models_annotating_a_file_frozen_spec.rb
+++ b/spec/lib/annotate/annotate_models_annotating_a_file_frozen_spec.rb
@@ -26,26 +26,6 @@ RSpec.describe AnnotateModels do
       Annotate::Helpers.reset_options(Annotate::Constants::ALL_ANNOTATE_OPTIONS)
     end
 
-    def write_model(file_name, file_content)
-      fname = File.join(@model_dir, file_name)
-      FileUtils.mkdir_p(File.dirname(fname))
-      File.open(fname, 'wb') { |f| f.write file_content }
-
-      [fname, file_content]
-    end
-
-    def annotate_one_file(options = {})
-      Annotate.set_defaults(options)
-      options = Annotate.setup_options(options)
-      AnnotateModels.annotate_one_file(@model_file_name, @schema_info, :position_in_class, options)
-
-      # Wipe settings so the next call will pick up new values...
-      Annotate.instance_variable_set('@has_set_defaults', false)
-      Annotate::Constants::POSITION_OPTIONS.each { |key| ENV[key.to_s] = '' }
-      Annotate::Constants::FLAG_OPTIONS.each { |key| ENV[key.to_s] = '' }
-      Annotate::Constants::PATH_OPTIONS.each { |key| ENV[key.to_s] = '' }
-    end
-
     # TODO: Check out why this test fails due to test pollution
     xdescribe 'frozen option' do
       it "should abort without existing annotation when frozen: true " do

--- a/spec/lib/annotate/annotate_models_annotating_a_file_frozen_spec.rb
+++ b/spec/lib/annotate/annotate_models_annotating_a_file_frozen_spec.rb
@@ -7,7 +7,6 @@ require 'tmpdir'
 
 RSpec.describe AnnotateModels do
   include AnnotateTestHelpers
-  include AnnotateTestConstants
 
   describe 'annotating a file' do
     before do

--- a/spec/lib/annotate/annotate_models_annotating_a_file_frozen_spec.rb
+++ b/spec/lib/annotate/annotate_models_annotating_a_file_frozen_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe AnnotateModels do
     end
 
     # TODO: Check out why this test fails due to test pollution
-    xdescribe 'frozen option' do
+    describe 'frozen option' do
       it "should abort without existing annotation when frozen: true " do
         expect { annotate_one_file frozen: true }.to raise_error SystemExit, /user.rb needs to be updated, but annotate was run with `--frozen`./
       end

--- a/spec/lib/annotate/annotate_models_annotating_a_file_frozen_spec.rb
+++ b/spec/lib/annotate/annotate_models_annotating_a_file_frozen_spec.rb
@@ -7,20 +7,7 @@ require 'tmpdir'
 
 RSpec.describe AnnotateModels do
   include AnnotateTestHelpers
-
-  MAGIC_COMMENTS = [
-    '# encoding: UTF-8',
-    '# coding: UTF-8',
-    '# -*- coding: UTF-8 -*-',
-    '#encoding: utf-8',
-    '# encoding: utf-8',
-    '# -*- encoding : utf-8 -*-',
-    "# encoding: utf-8\n# frozen_string_literal: true",
-    "# frozen_string_literal: true\n# encoding: utf-8",
-    '# frozen_string_literal: true',
-    '#frozen_string_literal: false',
-    '# -*- frozen_string_literal : true -*-'
-  ].freeze
+  include AnnotateTestConstants
 
   describe 'annotating a file' do
     before do

--- a/spec/lib/annotate/annotate_models_annotating_a_file_spec.rb
+++ b/spec/lib/annotate/annotate_models_annotating_a_file_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe AnnotateModels do
     end
 
     it 'should not touch magic comments' do
-      MAGIC_COMMENTS.each do |magic_comment|
+      AnnotateTestConstants::MAGIC_COMMENTS.each do |magic_comment|
         write_model 'user.rb', <<~EOS
           #{magic_comment}
           class User < ActiveRecord::Base
@@ -266,7 +266,7 @@ RSpec.describe AnnotateModels do
 
     it 'adds an empty line between magic comments and annotation (position :before)' do
       content = "class User < ActiveRecord::Base\nend\n"
-      MAGIC_COMMENTS.each do |magic_comment|
+      AnnotateTestConstants::MAGIC_COMMENTS.each do |magic_comment|
         model_file_name, = write_model 'user.rb', "#{magic_comment}\n#{content}"
 
         annotate_one_file position: :before
@@ -278,7 +278,7 @@ RSpec.describe AnnotateModels do
 
     it 'only keeps a single empty line around the annotation (position :before)' do
       content = "class User < ActiveRecord::Base\nend\n"
-      MAGIC_COMMENTS.each do |magic_comment|
+      AnnotateTestConstants::MAGIC_COMMENTS.each do |magic_comment|
         schema_info = AnnotateModels::SchemaInfo.generate(@klass, '== Schema Info')
         model_file_name, = write_model 'user.rb', "#{magic_comment}\n\n\n\n#{content}"
 
@@ -290,7 +290,7 @@ RSpec.describe AnnotateModels do
 
     it 'does not change whitespace between magic comments and model file content (position :after)' do
       content = "class User < ActiveRecord::Base\nend\n"
-      MAGIC_COMMENTS.each do |magic_comment|
+      AnnotateTestConstants::MAGIC_COMMENTS.each do |magic_comment|
         model_file_name, = write_model 'user.rb', "#{magic_comment}\n#{content}"
 
         annotate_one_file position: :after

--- a/spec/lib/annotate/annotate_models_annotating_a_file_spec.rb
+++ b/spec/lib/annotate/annotate_models_annotating_a_file_spec.rb
@@ -61,16 +61,80 @@ RSpec.describe AnnotateModels do
       Annotate::Constants::PATH_OPTIONS.each { |key| ENV[key.to_s] = '' }
     end
 
-    ['before', :before, 'top', :top].each do |position|
-      it "should put annotation before class if :position == #{position}" do
+    context "with 'before'" do
+      let(:position) { 'before' }
+
+      it "should put annotation before class if :position == 'before'" do
         annotate_one_file position: position
         expect(File.read(@model_file_name))
           .to eq("#{@schema_info}#{@file_content}")
       end
     end
 
-    ['after', :after, 'bottom', :bottom].each do |position|
-      it "should put annotation after class if position: #{position}" do
+    context "with :before" do
+      let(:position) { :before }
+
+      it "should put annotation before class if :position == :before" do
+        annotate_one_file position: position
+        expect(File.read(@model_file_name))
+          .to eq("#{@schema_info}#{@file_content}")
+      end
+    end
+
+    context "with 'top'" do
+      let(:position) { 'top' }
+
+      it "should put annotation before class if :position == 'top'" do
+        annotate_one_file position: position
+        expect(File.read(@model_file_name))
+          .to eq("#{@schema_info}#{@file_content}")
+      end
+    end
+
+    context "with :top" do
+      let(:position) { :top }
+
+      it "should put annotation before class if :position == :top" do
+        annotate_one_file position: position
+        expect(File.read(@model_file_name))
+          .to eq("#{@schema_info}#{@file_content}")
+      end
+    end
+
+    context "with 'after'" do
+      let(:position) { 'after' }
+
+      it "should put annotation after class if position: 'after'" do
+        annotate_one_file position: position
+        expect(File.read(@model_file_name))
+          .to eq("#{@file_content}\n#{@schema_info}")
+      end
+    end
+
+    context "with :after" do
+      let(:position) { :after }
+
+      it "should put annotation after class if position: :after" do
+        annotate_one_file position: position
+        expect(File.read(@model_file_name))
+          .to eq("#{@file_content}\n#{@schema_info}")
+      end
+    end
+
+    context "with 'bottom'" do
+      let(:position) { 'bottom' }
+
+      it "should put annotation after class if position: 'bottom'" do
+        annotate_one_file position: position
+        expect(File.read(@model_file_name))
+          .to eq("#{@file_content}\n#{@schema_info}")
+      end
+    end
+
+    context "with :bottom" do
+      let(:position) { :bottom }
+
+      it "should put annotation after class if position: :bottom" do
         annotate_one_file position: position
         expect(File.read(@model_file_name))
           .to eq("#{@file_content}\n#{@schema_info}")

--- a/spec/lib/annotate/annotate_models_annotating_a_file_spec.rb
+++ b/spec/lib/annotate/annotate_models_annotating_a_file_spec.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require_relative '../../spec_helper'
 require 'annotate/annotate_models'
 require 'annotate/active_record_patch'
 require 'active_support/core_ext/string'

--- a/spec/lib/annotate/annotate_models_annotating_a_file_spec.rb
+++ b/spec/lib/annotate/annotate_models_annotating_a_file_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe AnnotateModels do
 
       # Wipe settings so the next call will pick up new values...
       Annotate.instance_variable_set('@has_set_defaults', false)
-      Annotate::Constants::POSITION_OPTIONS.each { |key| ENV[key.to_s] = '' }
-      Annotate::Constants::FLAG_OPTIONS.each { |key| ENV[key.to_s] = '' }
-      Annotate::Constants::PATH_OPTIONS.each { |key| ENV[key.to_s] = '' }
+      Annotate::Constants::POSITION_OPTIONS.each { |key| ENV[key.to_s] = nil }
+      Annotate::Constants::FLAG_OPTIONS.each { |key| ENV[key.to_s] = nil }
+      Annotate::Constants::PATH_OPTIONS.each { |key| ENV[key.to_s] = nil }
     end
 
     context "with 'before'" do

--- a/spec/lib/annotate/annotate_models_annotating_a_file_spec.rb
+++ b/spec/lib/annotate/annotate_models_annotating_a_file_spec.rb
@@ -27,26 +27,6 @@ RSpec.describe AnnotateModels do
       Annotate::Helpers.reset_options(Annotate::Constants::ALL_ANNOTATE_OPTIONS)
     end
 
-    def write_model(file_name, file_content)
-      fname = File.join(@model_dir, file_name)
-      FileUtils.mkdir_p(File.dirname(fname))
-      File.open(fname, 'wb') { |f| f.write file_content }
-
-      [fname, file_content]
-    end
-
-    def annotate_one_file(options = {})
-      Annotate.set_defaults(options)
-      options = Annotate.setup_options(options)
-      AnnotateModels.annotate_one_file(@model_file_name, @schema_info, :position_in_class, options)
-
-      # Wipe settings so the next call will pick up new values...
-      Annotate.instance_variable_set('@has_set_defaults', false)
-      Annotate::Constants::POSITION_OPTIONS.each { |key| ENV[key.to_s] = nil }
-      Annotate::Constants::FLAG_OPTIONS.each { |key| ENV[key.to_s] = nil }
-      Annotate::Constants::PATH_OPTIONS.each { |key| ENV[key.to_s] = nil }
-    end
-
     context "with 'before'" do
       let(:position) { 'before' }
 

--- a/spec/lib/annotate/annotate_models_annotating_a_file_spec.rb
+++ b/spec/lib/annotate/annotate_models_annotating_a_file_spec.rb
@@ -7,20 +7,7 @@ require 'tmpdir'
 
 RSpec.describe AnnotateModels do
   include AnnotateTestHelpers
-
-  MAGIC_COMMENTS = [
-    '# encoding: UTF-8',
-    '# coding: UTF-8',
-    '# -*- coding: UTF-8 -*-',
-    '#encoding: utf-8',
-    '# encoding: utf-8',
-    '# -*- encoding : utf-8 -*-',
-    "# encoding: utf-8\n# frozen_string_literal: true",
-    "# frozen_string_literal: true\n# encoding: utf-8",
-    '# frozen_string_literal: true',
-    '#frozen_string_literal: false',
-    '# -*- frozen_string_literal : true -*-'
-  ].freeze
+  include AnnotateTestConstants
 
   describe 'annotating a file' do
     before do

--- a/spec/lib/annotate/annotate_models_get_model_class_spec.rb
+++ b/spec/lib/annotate/annotate_models_get_model_class_spec.rb
@@ -5,8 +5,6 @@ require 'active_support/core_ext/string'
 require 'tmpdir'
 
 RSpec.describe AnnotateModels do
-  include AnnotateTestConstants
-
   describe '.get_model_class' do
     def create(filename, file_content)
       File.join(AnnotateModels.model_dir[0], filename).tap do |path|

--- a/spec/lib/annotate/annotate_models_get_model_class_spec.rb
+++ b/spec/lib/annotate/annotate_models_get_model_class_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe AnnotateModels do
       end
     end
 
-    before :each do
+    before do
+      AnnotateModels.model_dir = Dir.mktmpdir('annotate_models')
       create(filename, file_content)
     end
 
@@ -279,7 +280,7 @@ RSpec.describe AnnotateModels do
     end
 
     context 'when two class exist' do
-      before :each do
+      before do
         create(filename_2, file_content_2)
       end
 
@@ -301,6 +302,7 @@ RSpec.describe AnnotateModels do
 
         let :file_content_2 do
           <<-EOS
+            module Bar; end
             class Bar::Foo
             end
           EOS

--- a/spec/lib/annotate/annotate_models_get_model_class_spec.rb
+++ b/spec/lib/annotate/annotate_models_get_model_class_spec.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require_relative '../../spec_helper'
 require 'annotate/annotate_models'
 require 'annotate/active_record_patch'
 require 'active_support/core_ext/string'

--- a/spec/lib/annotate/annotate_models_get_model_class_spec.rb
+++ b/spec/lib/annotate/annotate_models_get_model_class_spec.rb
@@ -5,26 +5,9 @@ require 'active_support/core_ext/string'
 require 'tmpdir'
 
 RSpec.describe AnnotateModels do
-  MAGIC_COMMENTS = [
-    '# encoding: UTF-8',
-    '# coding: UTF-8',
-    '# -*- coding: UTF-8 -*-',
-    '#encoding: utf-8',
-    '# encoding: utf-8',
-    '# -*- encoding : utf-8 -*-',
-    "# encoding: utf-8\n# frozen_string_literal: true",
-    "# frozen_string_literal: true\n# encoding: utf-8",
-    '# frozen_string_literal: true',
-    '#frozen_string_literal: false',
-    '# -*- frozen_string_literal : true -*-'
-  ].freeze
+  include AnnotateTestConstants
 
   describe '.get_model_class' do
-    before do
-      AnnotateModels.model_dir = Dir.mktmpdir('annotate_models')
-    end
-
-    # TODO: use 'files' gem instead
     def create(filename, file_content)
       File.join(AnnotateModels.model_dir[0], filename).tap do |path|
         FileUtils.mkdir_p(File.dirname(path))

--- a/spec/lib/annotate/annotate_models_get_model_class_spec.rb
+++ b/spec/lib/annotate/annotate_models_get_model_class_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe AnnotateModels do
           EOS
         end
 
-        before :each do
+        before do
           path = File.expand_path(filename, AnnotateModels.model_dir[0])
           Kernel.load(path)
           expect(Kernel).not_to receive(:require)
@@ -250,7 +250,7 @@ RSpec.describe AnnotateModels do
         dir = Array.new(8) { (0..9).to_a.sample(random: Random.new) }.join
 
         context "when class SubdirLoadedClass is defined in \"#{dir}/subdir_loaded_class.rb\"" do
-          before :each do
+          before do
             $LOAD_PATH.unshift(File.join(AnnotateModels.model_dir[0], dir))
 
             path = File.expand_path(filename, AnnotateModels.model_dir[0])

--- a/spec/lib/annotate/annotate_models_get_model_files_spec.rb
+++ b/spec/lib/annotate/annotate_models_get_model_files_spec.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require_relative '../../spec_helper'
 require 'annotate/annotate_models'
 require 'annotate/active_record_patch'
 require 'active_support/core_ext/string'

--- a/spec/lib/annotate/annotate_models_get_model_files_spec.rb
+++ b/spec/lib/annotate/annotate_models_get_model_files_spec.rb
@@ -6,8 +6,6 @@ require 'files'
 require 'tmpdir'
 
 RSpec.describe AnnotateModels do
-  include AnnotateTestConstants
-
   describe '.get_model_files' do
     subject { described_class.get_model_files(options) }
 

--- a/spec/lib/annotate/annotate_models_get_model_files_spec.rb
+++ b/spec/lib/annotate/annotate_models_get_model_files_spec.rb
@@ -6,19 +6,7 @@ require 'files'
 require 'tmpdir'
 
 RSpec.describe AnnotateModels do
-  MAGIC_COMMENTS = [
-    '# encoding: UTF-8',
-    '# coding: UTF-8',
-    '# -*- coding: UTF-8 -*-',
-    '#encoding: utf-8',
-    '# encoding: utf-8',
-    '# -*- encoding : utf-8 -*-',
-    "# encoding: utf-8\n# frozen_string_literal: true",
-    "# frozen_string_literal: true\n# encoding: utf-8",
-    '# frozen_string_literal: true',
-    '#frozen_string_literal: false',
-    '# -*- frozen_string_literal : true -*-'
-  ].freeze
+  include AnnotateTestConstants
 
   describe '.get_model_files' do
     subject { described_class.get_model_files(options) }

--- a/spec/lib/annotate/annotate_models_get_patterns_spec.rb
+++ b/spec/lib/annotate/annotate_models_get_patterns_spec.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require_relative '../../spec_helper'
 require 'annotate/annotate_models'
 require 'annotate/active_record_patch'
 require 'active_support/core_ext/string'

--- a/spec/lib/annotate/annotate_models_get_patterns_spec.rb
+++ b/spec/lib/annotate/annotate_models_get_patterns_spec.rb
@@ -6,8 +6,6 @@ require 'files'
 require 'tmpdir'
 
 RSpec.describe AnnotateModels do
-  include AnnotateTestConstants
-
   describe '.get_patterns' do
     subject { AnnotateModels.get_patterns(options, pattern_type) }
 

--- a/spec/lib/annotate/annotate_models_get_patterns_spec.rb
+++ b/spec/lib/annotate/annotate_models_get_patterns_spec.rb
@@ -6,19 +6,7 @@ require 'files'
 require 'tmpdir'
 
 RSpec.describe AnnotateModels do
-  MAGIC_COMMENTS = [
-    '# encoding: UTF-8',
-    '# coding: UTF-8',
-    '# -*- coding: UTF-8 -*-',
-    '#encoding: utf-8',
-    '# encoding: utf-8',
-    '# -*- encoding : utf-8 -*-',
-    "# encoding: utf-8\n# frozen_string_literal: true",
-    "# frozen_string_literal: true\n# encoding: utf-8",
-    '# frozen_string_literal: true',
-    '#frozen_string_literal: false',
-    '# -*- frozen_string_literal : true -*-'
-  ].freeze
+  include AnnotateTestConstants
 
   describe '.get_patterns' do
     subject { AnnotateModels.get_patterns(options, pattern_type) }

--- a/spec/lib/annotate/annotate_models_parse_options_spec.rb
+++ b/spec/lib/annotate/annotate_models_parse_options_spec.rb
@@ -6,19 +6,7 @@ require 'files'
 require 'tmpdir'
 
 RSpec.describe AnnotateModels do
-  MAGIC_COMMENTS = [
-    '# encoding: UTF-8',
-    '# coding: UTF-8',
-    '# -*- coding: UTF-8 -*-',
-    '#encoding: utf-8',
-    '# encoding: utf-8',
-    '# -*- encoding : utf-8 -*-',
-    "# encoding: utf-8\n# frozen_string_literal: true",
-    "# frozen_string_literal: true\n# encoding: utf-8",
-    '# frozen_string_literal: true',
-    '#frozen_string_literal: false',
-    '# -*- frozen_string_literal : true -*-'
-  ].freeze
+  include AnnotateTestConstants
 
   describe '.parse_options' do
     let(:options) do

--- a/spec/lib/annotate/annotate_models_parse_options_spec.rb
+++ b/spec/lib/annotate/annotate_models_parse_options_spec.rb
@@ -6,8 +6,6 @@ require 'files'
 require 'tmpdir'
 
 RSpec.describe AnnotateModels do
-  include AnnotateTestConstants
-
   describe '.parse_options' do
     let(:options) do
       {

--- a/spec/lib/annotate/annotate_models_parse_options_spec.rb
+++ b/spec/lib/annotate/annotate_models_parse_options_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe AnnotateModels do
       }
     end
 
-    before :each do
+    before do
       AnnotateModels.send(:parse_options, options)
     end
 

--- a/spec/lib/annotate/annotate_models_parse_options_spec.rb
+++ b/spec/lib/annotate/annotate_models_parse_options_spec.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require_relative '../../spec_helper'
 require 'annotate/annotate_models'
 require 'annotate/active_record_patch'
 require 'active_support/core_ext/string'

--- a/spec/lib/annotate/annotate_models_remove_annotation_of_file_spec.rb
+++ b/spec/lib/annotate/annotate_models_remove_annotation_of_file_spec.rb
@@ -6,19 +6,7 @@ require 'files'
 require 'tmpdir'
 
 RSpec.describe AnnotateModels do
-  MAGIC_COMMENTS = [
-    '# encoding: UTF-8',
-    '# coding: UTF-8',
-    '# -*- coding: UTF-8 -*-',
-    '#encoding: utf-8',
-    '# encoding: utf-8',
-    '# -*- encoding : utf-8 -*-',
-    "# encoding: utf-8\n# frozen_string_literal: true",
-    "# frozen_string_literal: true\n# encoding: utf-8",
-    '# frozen_string_literal: true',
-    '#frozen_string_literal: false',
-    '# -*- frozen_string_literal : true -*-'
-  ].freeze
+  include AnnotateTestConstants
 
   describe '.remove_annotation_of_file' do
     subject do

--- a/spec/lib/annotate/annotate_models_remove_annotation_of_file_spec.rb
+++ b/spec/lib/annotate/annotate_models_remove_annotation_of_file_spec.rb
@@ -6,8 +6,6 @@ require 'files'
 require 'tmpdir'
 
 RSpec.describe AnnotateModels do
-  include AnnotateTestConstants
-
   describe '.remove_annotation_of_file' do
     subject do
       AnnotateModels.remove_annotation_of_file(path)

--- a/spec/lib/annotate/annotate_models_remove_annotation_of_file_spec.rb
+++ b/spec/lib/annotate/annotate_models_remove_annotation_of_file_spec.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require_relative '../../spec_helper'
 require 'annotate/annotate_models'
 require 'annotate/active_record_patch'
 require 'active_support/core_ext/string'

--- a/spec/lib/annotate/annotate_models_resolve_filename_spec.rb
+++ b/spec/lib/annotate/annotate_models_resolve_filename_spec.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require_relative '../../spec_helper'
 require 'annotate/annotate_models'
 require 'annotate/active_record_patch'
 require 'active_support/core_ext/string'

--- a/spec/lib/annotate/annotate_models_resolve_filename_spec.rb
+++ b/spec/lib/annotate/annotate_models_resolve_filename_spec.rb
@@ -6,19 +6,7 @@ require 'files'
 require 'tmpdir'
 
 RSpec.describe AnnotateModels do
-  MAGIC_COMMENTS = [
-    '# encoding: UTF-8',
-    '# coding: UTF-8',
-    '# -*- coding: UTF-8 -*-',
-    '#encoding: utf-8',
-    '# encoding: utf-8',
-    '# -*- encoding : utf-8 -*-',
-    "# encoding: utf-8\n# frozen_string_literal: true",
-    "# frozen_string_literal: true\n# encoding: utf-8",
-    '# frozen_string_literal: true',
-    '#frozen_string_literal: false',
-    '# -*- frozen_string_literal : true -*-'
-  ].freeze
+  include AnnotateTestConstants
 
   describe '.resolve_filename' do
     subject do

--- a/spec/lib/annotate/annotate_models_resolve_filename_spec.rb
+++ b/spec/lib/annotate/annotate_models_resolve_filename_spec.rb
@@ -6,8 +6,6 @@ require 'files'
 require 'tmpdir'
 
 RSpec.describe AnnotateModels do
-  include AnnotateTestConstants
-
   describe '.resolve_filename' do
     subject do
       AnnotateModels.resolve_filename(filename_template, model_name, table_name)

--- a/spec/lib/annotate/annotate_models_set_defaults_spec.rb
+++ b/spec/lib/annotate/annotate_models_set_defaults_spec.rb
@@ -6,19 +6,7 @@ require 'files'
 require 'tmpdir'
 
 RSpec.describe AnnotateModels do
-  MAGIC_COMMENTS = [
-    '# encoding: UTF-8',
-    '# coding: UTF-8',
-    '# -*- coding: UTF-8 -*-',
-    '#encoding: utf-8',
-    '# encoding: utf-8',
-    '# -*- encoding : utf-8 -*-',
-    "# encoding: utf-8\n# frozen_string_literal: true",
-    "# frozen_string_literal: true\n# encoding: utf-8",
-    '# frozen_string_literal: true',
-    '#frozen_string_literal: false',
-    '# -*- frozen_string_literal : true -*-'
-  ].freeze
+  include AnnotateTestConstants
 
   describe '.set_defaults' do
     subject do

--- a/spec/lib/annotate/annotate_models_set_defaults_spec.rb
+++ b/spec/lib/annotate/annotate_models_set_defaults_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe AnnotateModels do
       end
     end
 
-    after :each do
+    after do
       ENV.delete('show_complete_foreign_keys')
     end
   end

--- a/spec/lib/annotate/annotate_models_set_defaults_spec.rb
+++ b/spec/lib/annotate/annotate_models_set_defaults_spec.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require_relative '../../spec_helper'
 require 'annotate/annotate_models'
 require 'annotate/active_record_patch'
 require 'active_support/core_ext/string'

--- a/spec/lib/annotate/annotate_models_set_defaults_spec.rb
+++ b/spec/lib/annotate/annotate_models_set_defaults_spec.rb
@@ -22,13 +22,14 @@ RSpec.describe AnnotateModels do
         Annotate.set_defaults('show_complete_foreign_keys' => 'true')
       end
 
+      after do
+        Annotate.instance_variable_set('@has_set_defaults', false)
+        ENV.delete('show_complete_foreign_keys')
+      end
+
       it 'returns true' do
         is_expected.to be(true)
       end
-    end
-
-    after do
-      ENV.delete('show_complete_foreign_keys')
     end
   end
 end

--- a/spec/lib/annotate/annotate_models_set_defaults_spec.rb
+++ b/spec/lib/annotate/annotate_models_set_defaults_spec.rb
@@ -6,8 +6,6 @@ require 'files'
 require 'tmpdir'
 
 RSpec.describe AnnotateModels do
-  include AnnotateTestConstants
-
   describe '.set_defaults' do
     subject do
       Annotate::Helpers.true?(ENV['show_complete_foreign_keys'])

--- a/spec/lib/annotate/annotate_models_set_defaults_spec.rb
+++ b/spec/lib/annotate/annotate_models_set_defaults_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe AnnotateModels do
 
     context 'when default value of "show_complete_foreign_keys" is set' do
       before do
+        Annotate.instance_variable_set('@has_set_defaults', false)
         Annotate.set_defaults('show_complete_foreign_keys' => 'true')
       end
 

--- a/spec/lib/annotate/annotate_routes_spec.rb
+++ b/spec/lib/annotate/annotate_routes_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe AnnotateRoutes do
 
   describe '.do_annotations' do
     context 'When "config/routes.rb" does not exist' do
-      before :each do
+      before do
         expect(File).to receive(:exist?).with(ROUTE_FILE).and_return(false).once
       end
 
@@ -42,7 +42,7 @@ RSpec.describe AnnotateRoutes do
     end
 
     context 'When "config/routes.rb" exists' do
-      before :each do
+      before do
         expect(File).to receive(:exist?).with(ROUTE_FILE).and_return(true).once
         expect(File).to receive(:read).with(ROUTE_FILE).and_return(route_file_content).once
 
@@ -556,7 +556,7 @@ RSpec.describe AnnotateRoutes do
   end
 
   describe '.remove_annotations' do
-    before :each do
+    before do
       expect(File).to receive(:exist?).with(ROUTE_FILE).and_return(true).once
       expect(File).to receive(:read).with(ROUTE_FILE).and_return(route_file_content).once
       expect(File).to receive(:open).with(ROUTE_FILE, 'wb').and_yield(mock_file).once

--- a/spec/support/annotate_test_constants.rb
+++ b/spec/support/annotate_test_constants.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module AnnotateTestConstants
+  MAGIC_COMMENTS = [
+    '# encoding: UTF-8',
+    '# coding: UTF-8',
+    '# -*- coding: UTF-8 -*-',
+    '#encoding: utf-8',
+    '# encoding: utf-8',
+    '# -*- encoding : utf-8 -*-',
+    "# encoding: utf-8\n# frozen_string_literal: true",
+    "# frozen_string_literal: true\n# encoding: utf-8",
+    '# frozen_string_literal: true',
+    '#frozen_string_literal: false',
+    '# -*- frozen_string_literal : true -*-'
+  ].freeze
+end

--- a/spec/support/annotate_test_helpers.rb
+++ b/spec/support/annotate_test_helpers.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 module AnnotateTestHelpers
+
+  # This method is used to debug flakes/test pollution due to relying on ENV
+  # Can remove after the dependency on ENV is removed
+  def self.print_annotate_env_values
+    keys = Annotate::Constants::ALL_ANNOTATE_OPTIONS.flatten.map(&:to_s)
+    pp ENV.to_h.slice(*keys)
+  end
+
   def mock_index(name, params = {})
     double('IndexKeyDefinition',
            name: name,

--- a/spec/support/annotate_test_helpers.rb
+++ b/spec/support/annotate_test_helpers.rb
@@ -9,6 +9,27 @@ module AnnotateTestHelpers
     pp ENV.to_h.slice(*keys)
   end
 
+  def annotate_one_file(options = {})
+    Annotate.instance_variable_set('@has_set_defaults', false)
+    Annotate.set_defaults(options)
+    options = Annotate.setup_options(options)
+    AnnotateModels.annotate_one_file(@model_file_name, @schema_info, :position_in_class, options)
+
+    # Wipe settings so the next call will pick up new values...
+    Annotate.instance_variable_set('@has_set_defaults', false)
+    Annotate::Constants::POSITION_OPTIONS.each { |key| ENV[key.to_s] = nil }
+    Annotate::Constants::FLAG_OPTIONS.each { |key| ENV[key.to_s] = nil }
+    Annotate::Constants::PATH_OPTIONS.each { |key| ENV[key.to_s] = nil }
+  end
+
+  def write_model(file_name, file_content)
+    fname = File.join(@model_dir, file_name)
+    FileUtils.mkdir_p(File.dirname(fname))
+    File.open(fname, 'wb') { |f| f.write file_content }
+
+    [fname, file_content]
+  end
+
   def mock_index(name, params = {})
     double('IndexKeyDefinition',
            name: name,


### PR DESCRIPTION
The goal is to get CI green so that we can make behavior and structural changes with confidence.

I've found the following sources of test pollution:
- ENV values being written to and not cleaned up between tests
- `Annotate` has the instance variable, `@has_set_defaults`, which can persist between tests