### PR TITLE
Regularly run CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - '*'
 
+  schedule:
+    - cron: '0 0 * * *'
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR changes the CI action to run every day at midnight UTC. This is done to regularly check if there are any flakes in the test suite.