### PR TITLE
Add configuration instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,16 @@ Additional options that work for annotating models and routes
 
 ## Configuration
 
+### Storing default options
+Previously in the [Annotate](https://github.com/ctran/annotate_models) you could pass options through the CLI or store them as environment variables. Annotaterb removes dependency on the environment variables and instead can read values from a `.annotaterb.yml` file stored in the Rails project root.
+
+```yml
+# .annotaterb.yml
+
+position: after
+```
+
+Annotaterb reads first from the configuration file, if it exists, then merges it with any options passed into the CLI.
 
 ### How to skip annotating a particular model
 If you want to always skip annotations on a particular model, add this string

--- a/dummyapp/Gemfile.lock
+++ b/dummyapp/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    annotaterb (4.0.0)
+    annotaterb (4.0.0.beta.1)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
To assist with any folks migrating over that modified options in `annotate_models.rake` or `annotate_routes.rake` OR used env variables.