### PR TITLE
Refactor ModelAnnotator

### DIFF
--- a/lib/annotate_rb/model_annotator.rb
+++ b/lib/annotate_rb/model_annotator.rb
@@ -23,5 +23,6 @@ module AnnotateRb
     autoload :ColumnAnnotationBuilder, 'annotate_rb/model_annotator/column_annotation_builder'
     autoload :IndexAnnotationBuilder, 'annotate_rb/model_annotator/index_annotation_builder'
     autoload :ForeignKeyAnnotationBuilder, 'annotate_rb/model_annotator/foreign_key_annotation_builder'
+    autoload :RelatedFilesListBuilder, 'annotate_rb/model_annotator/related_files_list_builder'
   end
 end

--- a/lib/annotate_rb/model_annotator.rb
+++ b/lib/annotate_rb/model_annotator.rb
@@ -24,5 +24,6 @@ module AnnotateRb
     autoload :IndexAnnotationBuilder, 'annotate_rb/model_annotator/index_annotation_builder'
     autoload :ForeignKeyAnnotationBuilder, 'annotate_rb/model_annotator/foreign_key_annotation_builder'
     autoload :RelatedFilesListBuilder, 'annotate_rb/model_annotator/related_files_list_builder'
+    autoload :AnnotationDecider, 'annotate_rb/model_annotator/annotation_decider'
   end
 end

--- a/lib/annotate_rb/model_annotator.rb
+++ b/lib/annotate_rb/model_annotator.rb
@@ -25,5 +25,6 @@ module AnnotateRb
     autoload :ForeignKeyAnnotationBuilder, 'annotate_rb/model_annotator/foreign_key_annotation_builder'
     autoload :RelatedFilesListBuilder, 'annotate_rb/model_annotator/related_files_list_builder'
     autoload :AnnotationDecider, 'annotate_rb/model_annotator/annotation_decider'
+    autoload :FileAnnotatorInstruction, 'annotate_rb/model_annotator/file_annotator_instruction'
   end
 end

--- a/lib/annotate_rb/model_annotator/annotation_decider.rb
+++ b/lib/annotate_rb/model_annotator/annotation_decider.rb
@@ -10,7 +10,7 @@ module AnnotateRb
       end
 
       def annotate?
-        return false if /#{Constants::SKIP_ANNOTATION_PREFIX}.*/ =~ (File.exist?(@file) ? File.read(@file) : '')
+        return false if file_contains_skip_annotation
 
         begin
           klass = ModelClassGetter.call(@file, @options)
@@ -44,6 +44,18 @@ module AnnotateRb
         end
 
         false
+      end
+
+      private
+
+      def file_contains_skip_annotation
+        file_string = File.exist?(@file) ? File.read(@file) : ''
+
+        if /#{Constants::SKIP_ANNOTATION_PREFIX}.*/ =~ file_string
+          true
+        else
+          false
+        end
       end
     end
   end

--- a/lib/annotate_rb/model_annotator/annotation_decider.rb
+++ b/lib/annotate_rb/model_annotator/annotation_decider.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module AnnotateRb
+  module ModelAnnotator
+    # Class that encapsulates the logic to decide whether to annotate a model file and its related files or not.
+    class AnnotationDecider
+      def initialize(file, options)
+        @file = file
+        @options = options
+      end
+
+      def annotate?
+        return false if /#{Constants::SKIP_ANNOTATION_PREFIX}.*/ =~ (File.exist?(@file) ? File.read(@file) : '')
+
+        klass = ModelClassGetter.call(@file, @options)
+
+        klass_is_a_class = klass.is_a?(Class)
+        klass_inherits_active_record_base = klass < ActiveRecord::Base
+        klass_is_not_abstract = klass.respond_to?(:abstract_class) && !klass.abstract_class?
+        klass_table_exists = klass.respond_to?(:abstract_class) && klass.table_exists?
+
+        not_sure_this_conditional = (!@options[:exclude_sti_subclasses] || !(klass.superclass < ActiveRecord::Base && klass.table_name == klass.superclass.table_name))
+
+        annotate_conditions = [
+          klass_is_a_class,
+          klass_inherits_active_record_base,
+          not_sure_this_conditional,
+          klass_is_not_abstract,
+          klass_table_exists
+        ]
+
+        _to_annotate = annotate_conditions.all?
+      end
+    end
+  end
+end

--- a/lib/annotate_rb/model_annotator/annotation_decider.rb
+++ b/lib/annotate_rb/model_annotator/annotation_decider.rb
@@ -12,24 +12,38 @@ module AnnotateRb
       def annotate?
         return false if /#{Constants::SKIP_ANNOTATION_PREFIX}.*/ =~ (File.exist?(@file) ? File.read(@file) : '')
 
-        klass = ModelClassGetter.call(@file, @options)
+        begin
+          klass = ModelClassGetter.call(@file, @options)
 
-        klass_is_a_class = klass.is_a?(Class)
-        klass_inherits_active_record_base = klass < ActiveRecord::Base
-        klass_is_not_abstract = klass.respond_to?(:abstract_class) && !klass.abstract_class?
-        klass_table_exists = klass.respond_to?(:abstract_class) && klass.table_exists?
+          klass_is_a_class = klass.is_a?(Class)
+          klass_inherits_active_record_base = klass < ActiveRecord::Base
+          klass_is_not_abstract = klass.respond_to?(:abstract_class) && !klass.abstract_class?
+          klass_table_exists = klass.respond_to?(:abstract_class) && klass.table_exists?
 
-        not_sure_this_conditional = (!@options[:exclude_sti_subclasses] || !(klass.superclass < ActiveRecord::Base && klass.table_name == klass.superclass.table_name))
+          not_sure_this_conditional = (!@options[:exclude_sti_subclasses] || !(klass.superclass < ActiveRecord::Base && klass.table_name == klass.superclass.table_name))
 
-        annotate_conditions = [
-          klass_is_a_class,
-          klass_inherits_active_record_base,
-          not_sure_this_conditional,
-          klass_is_not_abstract,
-          klass_table_exists
-        ]
+          annotate_conditions = [
+            klass_is_a_class,
+            klass_inherits_active_record_base,
+            not_sure_this_conditional,
+            klass_is_not_abstract,
+            klass_table_exists
+          ]
 
-        _to_annotate = annotate_conditions.all?
+          to_annotate = annotate_conditions.all?
+
+          return to_annotate
+        rescue BadModelFileError => e
+          unless @options[:ignore_unknown_models]
+            $stderr.puts "Unable to annotate #{@file}: #{e.message}"
+            $stderr.puts "\t" + e.backtrace.join("\n\t") if @options[:trace]
+          end
+        rescue StandardError => e
+          $stderr.puts "Unable to annotate #{@file}: #{e.message}"
+          $stderr.puts "\t" + e.backtrace.join("\n\t") if @options[:trace]
+        end
+
+        false
       end
     end
   end

--- a/lib/annotate_rb/model_annotator/annotation_generator.rb
+++ b/lib/annotate_rb/model_annotator/annotation_generator.rb
@@ -12,10 +12,9 @@ module AnnotateRb
       MD_NAMES_OVERHEAD = 6
       MD_TYPE_ALLOWANCE = 18
 
-      def initialize(klass, header, options = {})
-        @header = header
-        @options = options
+      def initialize(klass, options = {})
         @model = ModelWrapper.new(klass, options)
+        @options = options
         @info = "" # TODO: Make array and build string that way
       end
 
@@ -50,9 +49,15 @@ module AnnotateRb
         @info
       end
 
-      # TODO: Move header logic into here from AnnotateRb::ModelAnnotator::Annotator.do_annotations
       def header
-        @header
+        header = @options[:format_markdown] ? PREFIX_MD.dup : PREFIX.dup
+        version = ActiveRecord::Migrator.current_version rescue 0
+
+        if @options[:include_version] && version > 0
+          header += "\n# Schema version: #{version}"
+        end
+
+        header
       end
 
       def schema_header_text

--- a/lib/annotate_rb/model_annotator/annotator.rb
+++ b/lib/annotate_rb/model_annotator/annotator.rb
@@ -12,6 +12,9 @@ module AnnotateRb
         # then pass it to the associated block
         def do_annotations(options = {})
           annotated = []
+
+          # Currently ModelFilesGetter gets the model files we want to annotate. The list of model files then gets
+          # expanded in ModelFileAnnotator. This is unintuitive.
           model_files_to_annotate = ModelFilesGetter.call(options)
 
           model_files_to_annotate.each do |path, filename|

--- a/lib/annotate_rb/model_annotator/annotator.rb
+++ b/lib/annotate_rb/model_annotator/annotator.rb
@@ -17,8 +17,14 @@ module AnnotateRb
           # expanded in ModelFileAnnotator. This is unintuitive.
           model_files_to_annotate = ModelFilesGetter.call(options)
 
-          model_files_to_annotate.each do |path, filename|
-            ModelFileAnnotator.call(annotated, File.join(path, filename), options)
+          model_files_to_actually_annotate = model_files_to_annotate.select do |path, filename|
+            file = File.join(path, filename)
+            AnnotationDecider.new(file, options).annotate?
+          end
+
+          model_files_to_actually_annotate.each do |path, filename|
+            file = File.join(path, filename)
+            ModelFileAnnotator.call(annotated, file, options)
           end
 
           if annotated.empty?

--- a/lib/annotate_rb/model_annotator/annotator.rb
+++ b/lib/annotate_rb/model_annotator/annotator.rb
@@ -6,15 +6,11 @@ module AnnotateRb
       MAGIC_COMMENT_MATCHER = Regexp.new(/(^#\s*encoding:.*(?:\n|r\n))|(^# coding:.*(?:\n|\r\n))|(^# -\*- coding:.*(?:\n|\r\n))|(^# -\*- encoding\s?:.*(?:\n|\r\n))|(^#\s*frozen_string_literal:.+(?:\n|\r\n))|(^# -\*- frozen_string_literal\s*:.+-\*-(?:\n|\r\n))/).freeze
 
       class << self
-        # We're passed a name of things that might be
-        # ActiveRecord models. If we can find the class, and
-        # if its a subclass of ActiveRecord::Base,
-        # then pass it to the associated block
+        # We're passed a name of things that might be ActiveRecord models. If we can find the class, and
+        # if its a subclass of ActiveRecord::Base, then pass it to the associated block
         def do_annotations(options = {})
           annotated = []
 
-          # Currently ModelFilesGetter gets the model files we want to annotate. The list of model files then gets
-          # expanded in ModelFileAnnotator. This is unintuitive.
           model_files_to_annotate = ModelFilesGetter.call(options)
 
           model_files_to_annotate.each do |path, filename|

--- a/lib/annotate_rb/model_annotator/annotator.rb
+++ b/lib/annotate_rb/model_annotator/annotator.rb
@@ -3,10 +3,6 @@
 module AnnotateRb
   module ModelAnnotator
     class Annotator
-      # Annotate Models plugin use this header
-      PREFIX = '== Schema Information'.freeze
-      PREFIX_MD = '## Schema Information'.freeze
-
       MAGIC_COMMENT_MATCHER = Regexp.new(/(^#\s*encoding:.*(?:\n|r\n))|(^# coding:.*(?:\n|\r\n))|(^# -\*- coding:.*(?:\n|\r\n))|(^# -\*- encoding\s?:.*(?:\n|\r\n))|(^#\s*frozen_string_literal:.+(?:\n|\r\n))|(^# -\*- frozen_string_literal\s*:.+-\*-(?:\n|\r\n))/).freeze
 
       class << self
@@ -15,17 +11,11 @@ module AnnotateRb
         # if its a subclass of ActiveRecord::Base,
         # then pass it to the associated block
         def do_annotations(options = {})
-          header = options[:format_markdown] ? PREFIX_MD.dup : PREFIX.dup
-          version = ActiveRecord::Migrator.current_version rescue 0
-          if options[:include_version] && version > 0
-            header += "\n# Schema version: #{version}"
-          end
-
           annotated = []
           model_files_to_annotate = ModelFilesGetter.call(options)
 
           model_files_to_annotate.each do |path, filename|
-            ModelFileAnnotator.call(annotated, File.join(path, filename), header, options)
+            ModelFileAnnotator.call(annotated, File.join(path, filename), options)
           end
 
           if annotated.empty?

--- a/lib/annotate_rb/model_annotator/annotator.rb
+++ b/lib/annotate_rb/model_annotator/annotator.rb
@@ -17,14 +17,12 @@ module AnnotateRb
           # expanded in ModelFileAnnotator. This is unintuitive.
           model_files_to_annotate = ModelFilesGetter.call(options)
 
-          model_files_to_actually_annotate = model_files_to_annotate.select do |path, filename|
+          model_files_to_annotate.select do |path, filename|
             file = File.join(path, filename)
-            AnnotationDecider.new(file, options).annotate?
-          end
 
-          model_files_to_actually_annotate.each do |path, filename|
-            file = File.join(path, filename)
-            ModelFileAnnotator.call(annotated, file, options)
+            if AnnotationDecider.new(file, options).annotate?
+              ModelFileAnnotator.call(annotated, file, options)
+            end
           end
 
           if annotated.empty?

--- a/lib/annotate_rb/model_annotator/annotator.rb
+++ b/lib/annotate_rb/model_annotator/annotator.rb
@@ -1,4 +1,4 @@
-# require 'bigdecimal'
+# frozen_string_literal: true
 
 module AnnotateRb
   module ModelAnnotator
@@ -18,7 +18,7 @@ module AnnotateRb
           header = options[:format_markdown] ? PREFIX_MD.dup : PREFIX.dup
           version = ActiveRecord::Migrator.current_version rescue 0
           if options[:include_version] && version > 0
-            header << "\n# Schema version: #{version}"
+            header += "\n# Schema version: #{version}"
           end
 
           annotated = []

--- a/lib/annotate_rb/model_annotator/annotator.rb
+++ b/lib/annotate_rb/model_annotator/annotator.rb
@@ -11,9 +11,9 @@ module AnnotateRb
         def do_annotations(options = {})
           annotated = []
 
-          model_files_to_annotate = ModelFilesGetter.call(options)
+          model_files_to_consider = ModelFilesGetter.call(options)
 
-          model_files_to_annotate.each do |path, filename|
+          model_files_to_consider.each do |path, filename|
             file = File.join(path, filename)
 
             if AnnotationDecider.new(file, options).annotate?
@@ -30,34 +30,41 @@ module AnnotateRb
 
         def remove_annotations(options = {})
           deannotated = []
-          deannotated_klass = false
-          ModelFilesGetter.call(options).each do |file|
-            file = File.join(file)
+
+          model_files_to_consider = ModelFilesGetter.call(options)
+
+          model_files_to_consider.each do |path, filename|
+            deannotated_klass = false
+            file = File.join(path, filename)
+
             begin
               klass = ModelClassGetter.call(file, options)
               if klass < ActiveRecord::Base && !klass.abstract_class?
                 model_name = klass.name.underscore
                 table_name = klass.table_name
-                model_file_name = file
-                deannotated_klass = true if FileAnnotationRemover.call(model_file_name, options)
 
-                patterns = PatternGetter.call(options)
+                if FileAnnotationRemover.call(file, options)
+                  deannotated_klass = true
+                end
 
-                patterns
-                  .map { |f| FileNameResolver.call(f, model_name, table_name) }
-                  .each do |f|
+                related_files = RelatedFilesListBuilder.new(file, model_name, table_name, options).build
+
+                related_files.each do |f, _position_key|
                   if File.exist?(f)
                     FileAnnotationRemover.call(f, options)
-                    deannotated_klass = true
                   end
                 end
               end
-              deannotated << klass if deannotated_klass
+
+              if deannotated_klass
+                deannotated << klass
+              end
             rescue StandardError => e
               $stderr.puts "Unable to deannotate #{File.join(file)}: #{e.message}"
               $stderr.puts "\t" + e.backtrace.join("\n\t") if options[:trace]
             end
           end
+
           puts "Removed annotations from: #{deannotated.join(', ')}"
         end
       end

--- a/lib/annotate_rb/model_annotator/annotator.rb
+++ b/lib/annotate_rb/model_annotator/annotator.rb
@@ -4,8 +4,6 @@ module AnnotateRb
   module ModelAnnotator
     class Annotator
       class << self
-        # We're passed a name of things that might be ActiveRecord models. If we can find the class, and
-        # if its a subclass of ActiveRecord::Base, then pass it to the associated block
         def do_annotations(options = {})
           annotated = []
 

--- a/lib/annotate_rb/model_annotator/annotator.rb
+++ b/lib/annotate_rb/model_annotator/annotator.rb
@@ -17,7 +17,7 @@ module AnnotateRb
           # expanded in ModelFileAnnotator. This is unintuitive.
           model_files_to_annotate = ModelFilesGetter.call(options)
 
-          model_files_to_annotate.select do |path, filename|
+          model_files_to_annotate.each do |path, filename|
             file = File.join(path, filename)
 
             if AnnotationDecider.new(file, options).annotate?

--- a/lib/annotate_rb/model_annotator/annotator.rb
+++ b/lib/annotate_rb/model_annotator/annotator.rb
@@ -3,8 +3,6 @@
 module AnnotateRb
   module ModelAnnotator
     class Annotator
-      MAGIC_COMMENT_MATCHER = Regexp.new(/(^#\s*encoding:.*(?:\n|r\n))|(^# coding:.*(?:\n|\r\n))|(^# -\*- coding:.*(?:\n|\r\n))|(^# -\*- encoding\s?:.*(?:\n|\r\n))|(^#\s*frozen_string_literal:.+(?:\n|\r\n))|(^# -\*- frozen_string_literal\s*:.+-\*-(?:\n|\r\n))/).freeze
-
       class << self
         # We're passed a name of things that might be ActiveRecord models. If we can find the class, and
         # if its a subclass of ActiveRecord::Base, then pass it to the associated block

--- a/lib/annotate_rb/model_annotator/constants.rb
+++ b/lib/annotate_rb/model_annotator/constants.rb
@@ -15,6 +15,8 @@ module AnnotateRb
       ALL_ANNOTATE_OPTIONS = ::AnnotateRb::Options::ALL_OPTION_KEYS
 
       SKIP_ANNOTATION_PREFIX = '# -\*- SkipSchemaAnnotations'.freeze
+
+      MAGIC_COMMENT_MATCHER = Regexp.new(/(^#\s*encoding:.*(?:\n|r\n))|(^# coding:.*(?:\n|\r\n))|(^# -\*- coding:.*(?:\n|\r\n))|(^# -\*- encoding\s?:.*(?:\n|\r\n))|(^#\s*frozen_string_literal:.+(?:\n|\r\n))|(^# -\*- frozen_string_literal\s*:.+-\*-(?:\n|\r\n))/).freeze
     end
   end
 end

--- a/lib/annotate_rb/model_annotator/constants.rb
+++ b/lib/annotate_rb/model_annotator/constants.rb
@@ -1,8 +1,6 @@
 module AnnotateRb
   module ModelAnnotator
     module Constants
-      TRUE_RE = /^(true|t|yes|y|1)$/i.freeze
-
       ##
       # The set of available options to customize the behavior of Annotate.
       #

--- a/lib/annotate_rb/model_annotator/file_annotator.rb
+++ b/lib/annotate_rb/model_annotator/file_annotator.rb
@@ -4,6 +4,10 @@ module AnnotateRb
   module ModelAnnotator
     class FileAnnotator
       class << self
+        def call_with_instructions(instruction)
+          call(instruction.file, instruction.annotation, instruction.position, instruction.options)
+        end
+
         # Add a schema block to a file. If the file already contains
         # a schema info block (a comment starting with "== Schema Information"),
         # check if it matches the block that is already there. If so, leave it be.

--- a/lib/annotate_rb/model_annotator/file_annotator.rb
+++ b/lib/annotate_rb/model_annotator/file_annotator.rb
@@ -47,7 +47,7 @@ module AnnotateRb
           # need to insert it in correct position
           if old_annotation.empty? || options[:force]
             magic_comments_block = Helper.magic_comments_as_string(old_content)
-            old_content.gsub!(Annotator::MAGIC_COMMENT_MATCHER, '')
+            old_content.gsub!(Constants::MAGIC_COMMENT_MATCHER, '')
 
             annotation_pattern = AnnotationPatternGenerator.call(options)
             old_content.sub!(annotation_pattern, '')

--- a/lib/annotate_rb/model_annotator/file_annotator.rb
+++ b/lib/annotate_rb/model_annotator/file_annotator.rb
@@ -33,7 +33,7 @@ module AnnotateRb
 
           return false if old_columns == new_columns && !options[:force]
 
-          abort "annotate error. #{file_name} needs to be updated, but annotate was run with `--frozen`." if options[:frozen]
+          abort "AnnotateRb error. #{file_name} needs to be updated, but annotaterb was run with `--frozen`." if options[:frozen]
 
           # Replace inline the old schema info with the new schema info
           wrapper_open = options[:wrapper_open] ? "# #{options[:wrapper_open]}\n" : ""

--- a/lib/annotate_rb/model_annotator/file_annotator_instruction.rb
+++ b/lib/annotate_rb/model_annotator/file_annotator_instruction.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module AnnotateRb
+  module ModelAnnotator
+    # A plain old Ruby object (PORO) that contains all necessary information for FileAnnotator
+    class FileAnnotatorInstruction
+      def initialize(file, annotation, position, options = {})
+        @file = file # Path to file
+        @annotation = annotation # Annotation string
+        @position = position # Position in the file where to write the annotation to
+        @options = options
+      end
+
+      attr_reader :file, :annotation, :position, :options
+    end
+  end
+end

--- a/lib/annotate_rb/model_annotator/helper.rb
+++ b/lib/annotate_rb/model_annotator/helper.rb
@@ -88,7 +88,7 @@ module AnnotateRb
         end
 
         def magic_comments_as_string(content)
-          magic_comments = content.scan(Annotator::MAGIC_COMMENT_MATCHER).flatten.compact
+          magic_comments = content.scan(Constants::MAGIC_COMMENT_MATCHER).flatten.compact
 
           if magic_comments.any?
             magic_comments.join

--- a/lib/annotate_rb/model_annotator/helper.rb
+++ b/lib/annotate_rb/model_annotator/helper.rb
@@ -3,8 +3,6 @@
 module AnnotateRb
   module ModelAnnotator
     module Helper
-      MATCHED_TYPES = %w(test fixture factory serializer scaffold controller helper).freeze
-
       INDEX_CLAUSES = {
         unique: {
           default: 'UNIQUE',
@@ -87,14 +85,6 @@ module AnnotateRb
 
         def width(string)
           string.chars.inject(0) { |acc, elem| acc + (elem.bytesize == 3 ? 2 : 1) }
-        end
-
-        def matched_types(options)
-          types = MATCHED_TYPES.dup
-          types << 'admin' if options[:active_admin] =~ Constants::TRUE_RE && !types.include?('admin')
-          types << 'additional_file_patterns' if options[:additional_file_patterns].present?
-
-          types
         end
 
         def magic_comments_as_string(content)

--- a/lib/annotate_rb/model_annotator/helper.rb
+++ b/lib/annotate_rb/model_annotator/helper.rb
@@ -97,10 +97,6 @@ module AnnotateRb
           end
         end
 
-        def true?(val)
-          val.present? && Constants::TRUE_RE.match?(val)
-        end
-
         # TODO: Find another implementation that doesn't depend on ActiveSupport
         def fallback(*args)
           args.compact.detect(&:present?)

--- a/lib/annotate_rb/model_annotator/model_file_annotator.rb
+++ b/lib/annotate_rb/model_annotator/model_file_annotator.rb
@@ -2,7 +2,7 @@
 
 module AnnotateRb
   module ModelAnnotator
-    # Not sure yet what the difference is between this and FileAnnotator
+    # Annotates a model file and its related files (controllers, factories, etc)
     class ModelFileAnnotator
       class << self
         def call(annotated, file, options)

--- a/lib/annotate_rb/model_annotator/model_file_annotator.rb
+++ b/lib/annotate_rb/model_annotator/model_file_annotator.rb
@@ -83,7 +83,7 @@ module AnnotateRb
               annotated << model_file_name
             end
 
-            Helper.matched_types(options).each do |key|
+            matched_types(options).each do |key|
               exclusion_key = "exclude_#{key.pluralize}".to_sym
               position_key = "position_in_#{key}".to_sym
 

--- a/lib/annotate_rb/model_annotator/model_file_annotator.rb
+++ b/lib/annotate_rb/model_annotator/model_file_annotator.rb
@@ -117,7 +117,7 @@ module AnnotateRb
 
         def matched_types(options)
           types = MATCHED_TYPES.dup
-          types << 'admin' if options[:active_admin] =~ Constants::TRUE_RE && !types.include?('admin')
+          types << 'admin' if options[:active_admin] && !types.include?('admin')
           types << 'additional_file_patterns' if options[:additional_file_patterns].present?
 
           types

--- a/lib/annotate_rb/model_annotator/model_file_annotator.rb
+++ b/lib/annotate_rb/model_annotator/model_file_annotator.rb
@@ -9,8 +9,14 @@ module AnnotateRb
           begin
             klass = ModelClassGetter.call(file, options)
 
-            files_annotated = annotate(klass, file, options)
-            annotated.concat(files_annotated)
+            instructions = build_instructions(klass, file, options)
+            instructions.each do |instruction|
+              if FileAnnotator.call_with_instructions(instruction)
+                annotated << instruction.file
+              end
+            end
+
+            annotated
           rescue BadModelFileError => e
             unless options[:ignore_unknown_models]
               $stderr.puts "Unable to annotate #{file}: #{e.message}"
@@ -24,36 +30,24 @@ module AnnotateRb
 
         private
 
-        def annotate(klass, file, options = {})
-          begin
-            klass.reset_column_information
-            info = AnnotationGenerator.new(klass, options).generate
-            model_name = klass.name.underscore
-            table_name = klass.table_name
-            model_file_name = File.join(file)
-            annotated = []
+        def build_instructions(klass, file, options = {})
+          instructions = []
 
-            instruction = FileAnnotatorInstruction.new(model_file_name, info, :position_in_class, options)
-            if FileAnnotator.call_with_instructions(instruction)
-              annotated << model_file_name
-            end
+          klass.reset_column_information
+          annotation = AnnotationGenerator.new(klass, options).generate
+          model_name = klass.name.underscore
+          table_name = klass.table_name
 
-            related_files = RelatedFilesListBuilder.new(file, model_name, table_name, options).build
+          model_instruction = FileAnnotatorInstruction.new(file, annotation, :position_in_class, options)
+          instructions << model_instruction
 
-            related_files.each do |f, position_key|
-              instruction = FileAnnotatorInstruction.new(f, info, position_key, options)
-
-              if FileAnnotator.call_with_instructions(instruction)
-                annotated << f
-              end
-            end
-
-          rescue StandardError => e
-            $stderr.puts "Unable to annotate #{file}: #{e.message}"
-            $stderr.puts "\t" + e.backtrace.join("\n\t") if options[:trace]
+          related_files = RelatedFilesListBuilder.new(file, model_name, table_name, options).build
+          related_file_instructions = related_files.map do |f, position_key|
+            _instruction = FileAnnotatorInstruction.new(f, annotation, position_key, options)
           end
+          instructions.concat(related_file_instructions)
 
-          annotated
+          instructions
         end
       end
     end

--- a/lib/annotate_rb/model_annotator/model_file_annotator.rb
+++ b/lib/annotate_rb/model_annotator/model_file_annotator.rb
@@ -7,13 +7,10 @@ module AnnotateRb
       class << self
         def call(annotated, file, options)
           begin
-            do_annotate = AnnotationDecider.new(file, options).annotate?
+            klass = ModelClassGetter.call(file, options)
 
-            if do_annotate
-              files_annotated = annotate(klass, file, options)
-              annotated.concat(files_annotated)
-            end
-
+            files_annotated = annotate(klass, file, options)
+            annotated.concat(files_annotated)
           rescue BadModelFileError => e
             unless options[:ignore_unknown_models]
               $stderr.puts "Unable to annotate #{file}: #{e.message}"

--- a/lib/annotate_rb/model_annotator/model_file_annotator.rb
+++ b/lib/annotate_rb/model_annotator/model_file_annotator.rb
@@ -7,25 +7,7 @@ module AnnotateRb
       class << self
         def call(annotated, file, options)
           begin
-            return false if /#{Constants::SKIP_ANNOTATION_PREFIX}.*/ =~ (File.exist?(file) ? File.read(file) : '')
-            klass = ModelClassGetter.call(file, options)
-
-            klass_is_a_class = klass.is_a?(Class)
-            klass_inherits_active_record_base = klass < ActiveRecord::Base
-            klass_is_not_abstract = klass.respond_to?(:abstract_class) && !klass.abstract_class?
-            klass_table_exists = klass.respond_to?(:abstract_class) && klass.table_exists?
-
-            not_sure_this_conditional = (!options[:exclude_sti_subclasses] || !(klass.superclass < ActiveRecord::Base && klass.table_name == klass.superclass.table_name))
-
-            annotate_conditions = [
-              klass_is_a_class,
-              klass_inherits_active_record_base,
-              not_sure_this_conditional,
-              klass_is_not_abstract,
-              klass_table_exists
-            ]
-
-            do_annotate = annotate_conditions.all?
+            do_annotate = AnnotationDecider.new(file, options).annotate?
 
             if do_annotate
               files_annotated = annotate(klass, file, options)

--- a/lib/annotate_rb/model_annotator/model_file_annotator.rb
+++ b/lib/annotate_rb/model_annotator/model_file_annotator.rb
@@ -83,7 +83,11 @@ module AnnotateRb
               annotated << model_file_name
             end
 
-            matched_types(options).each do |key|
+            types = MATCHED_TYPES.dup
+            types << 'admin' if options[:active_admin] && !types.include?('admin')
+            types << 'additional_file_patterns' if options[:additional_file_patterns].present?
+
+            types.each do |key|
               exclusion_key = "exclude_#{key.pluralize}".to_sym
               position_key = "position_in_#{key}".to_sym
 
@@ -113,14 +117,6 @@ module AnnotateRb
           end
 
           annotated
-        end
-
-        def matched_types(options)
-          types = MATCHED_TYPES.dup
-          types << 'admin' if options[:active_admin] && !types.include?('admin')
-          types << 'additional_file_patterns' if options[:additional_file_patterns].present?
-
-          types
         end
       end
     end

--- a/lib/annotate_rb/model_annotator/model_file_annotator.rb
+++ b/lib/annotate_rb/model_annotator/model_file_annotator.rb
@@ -4,6 +4,8 @@ module AnnotateRb
   module ModelAnnotator
     # Not sure yet what the difference is between this and FileAnnotator
     class ModelFileAnnotator
+      MATCHED_TYPES = %w(test fixture factory serializer scaffold controller helper).freeze
+
       class << self
         def call(annotated, file, options)
           begin
@@ -111,6 +113,14 @@ module AnnotateRb
           end
 
           annotated
+        end
+
+        def matched_types(options)
+          types = MATCHED_TYPES.dup
+          types << 'admin' if options[:active_admin] =~ Constants::TRUE_RE && !types.include?('admin')
+          types << 'additional_file_patterns' if options[:additional_file_patterns].present?
+
+          types
         end
       end
     end

--- a/lib/annotate_rb/model_annotator/model_file_annotator.rb
+++ b/lib/annotate_rb/model_annotator/model_file_annotator.rb
@@ -5,7 +5,7 @@ module AnnotateRb
     # Not sure yet what the difference is between this and FileAnnotator
     class ModelFileAnnotator
       class << self
-        def call(annotated, file, header, options)
+        def call(annotated, file, options)
           begin
             return false if /#{Constants::SKIP_ANNOTATION_PREFIX}.*/ =~ (File.exist?(file) ? File.read(file) : '')
             klass = ModelClassGetter.call(file, options)
@@ -28,7 +28,7 @@ module AnnotateRb
             do_annotate = annotate_conditions.all?
 
             if do_annotate
-              files_annotated = annotate(klass, file, header, options)
+              files_annotated = annotate(klass, file, options)
               annotated.concat(files_annotated)
             end
 
@@ -68,10 +68,10 @@ module AnnotateRb
         # == Returns:
         # an array of file names that were annotated.
         #
-        def annotate(klass, file, header, options = {})
+        def annotate(klass, file, options = {})
           begin
             klass.reset_column_information
-            info = AnnotationGenerator.new(klass, header, options).generate
+            info = AnnotationGenerator.new(klass, options).generate
             model_name = klass.name.underscore
             table_name = klass.table_name
             model_file_name = File.join(file)

--- a/lib/annotate_rb/model_annotator/model_file_annotator.rb
+++ b/lib/annotate_rb/model_annotator/model_file_annotator.rb
@@ -81,33 +81,7 @@ module AnnotateRb
               annotated << model_file_name
             end
 
-            related_files = []
-            types = %w(test fixture factory serializer scaffold controller helper)
-            types << 'admin' if options[:active_admin] && !types.include?('admin')
-            types << 'additional_file_patterns' if options[:additional_file_patterns].present?
-
-            types.each do |key|
-              exclusion_key = "exclude_#{key.pluralize}".to_sym
-              position_key = "position_in_#{key}".to_sym
-
-              # Same options for active_admin models
-              if key == 'admin'
-                exclusion_key = 'exclude_class'.to_sym
-                position_key = 'position_in_class'.to_sym
-              end
-
-              next if options[exclusion_key]
-
-              patterns = PatternGetter.call(options, key)
-
-              patterns
-                .map { |f| FileNameResolver.call(f, model_name, table_name) }
-                .map { |f| Dir.glob(f) }
-                .flatten
-                .each do |f|
-                  related_files << [f, position_key]
-              end
-            end
+            related_files = RelatedFilesListBuilder.new(file, model_name, table_name, options).build
 
             related_files.each do |f, position_key|
               if FileAnnotator.call(f, info, position_key, options)

--- a/lib/annotate_rb/model_annotator/model_file_annotator.rb
+++ b/lib/annotate_rb/model_annotator/model_file_annotator.rb
@@ -12,8 +12,8 @@ module AnnotateRb
 
             klass_is_a_class = klass.is_a?(Class)
             klass_inherits_active_record_base = klass < ActiveRecord::Base
-            klass_is_not_abstract = !klass.abstract_class?
-            klass_table_exists = klass.table_exists?
+            klass_is_not_abstract = klass.respond_to?(:abstract_class) && !klass.abstract_class?
+            klass_table_exists = klass.respond_to?(:abstract_class) && klass.table_exists?
 
             not_sure_this_conditional = (!options[:exclude_sti_subclasses] || !(klass.superclass < ActiveRecord::Base && klass.table_name == klass.superclass.table_name))
 

--- a/lib/annotate_rb/model_annotator/model_file_annotator.rb
+++ b/lib/annotate_rb/model_annotator/model_file_annotator.rb
@@ -45,29 +45,6 @@ module AnnotateRb
 
         private
 
-        # Given the name of an ActiveRecord class, create a schema
-        # info block (basically a comment containing information
-        # on the columns and their types) and put it at the front
-        # of the model and fixture source files.
-        #
-        # === Options (opts)
-        #  :position_in_class<Symbol>:: where to place the annotated section in model file
-        #  :position_in_test<Symbol>:: where to place the annotated section in test/spec file(s)
-        #  :position_in_fixture<Symbol>:: where to place the annotated section in fixture file
-        #  :position_in_factory<Symbol>:: where to place the annotated section in factory file
-        #  :position_in_serializer<Symbol>:: where to place the annotated section in serializer file
-        #  :exclude_tests<Symbol>:: whether to skip modification of test/spec files
-        #  :exclude_fixtures<Symbol>:: whether to skip modification of fixture files
-        #  :exclude_factories<Symbol>:: whether to skip modification of factory files
-        #  :exclude_serializers<Symbol>:: whether to skip modification of serializer files
-        #  :exclude_scaffolds<Symbol>:: whether to skip modification of scaffold files
-        #  :exclude_controllers<Symbol>:: whether to skip modification of controller files
-        #  :exclude_helpers<Symbol>:: whether to skip modification of helper files
-        #  :exclude_sti_subclasses<Symbol>:: whether to skip modification of files for STI subclasses
-        #
-        # == Returns:
-        # an array of file names that were annotated.
-        #
         def annotate(klass, file, options = {})
           begin
             klass.reset_column_information

--- a/lib/annotate_rb/model_annotator/model_file_annotator.rb
+++ b/lib/annotate_rb/model_annotator/model_file_annotator.rb
@@ -33,14 +33,17 @@ module AnnotateRb
             model_file_name = File.join(file)
             annotated = []
 
-            if FileAnnotator.call(model_file_name, info, :position_in_class, options)
+            instruction = FileAnnotatorInstruction.new(model_file_name, info, :position_in_class, options)
+            if FileAnnotator.call_with_instructions(instruction)
               annotated << model_file_name
             end
 
             related_files = RelatedFilesListBuilder.new(file, model_name, table_name, options).build
 
             related_files.each do |f, position_key|
-              if FileAnnotator.call(f, info, position_key, options)
+              instruction = FileAnnotatorInstruction.new(f, info, position_key, options)
+
+              if FileAnnotator.call_with_instructions(instruction)
                 annotated << f
               end
             end

--- a/lib/annotate_rb/model_annotator/model_files_getter.rb
+++ b/lib/annotate_rb/model_annotator/model_files_getter.rb
@@ -32,7 +32,7 @@ module AnnotateRb
         rescue SystemCallError
           $stderr.puts "No models found in directory '#{options[:model_dir].join("', '")}'."
           $stderr.puts "Either specify models on the command line, or use the --model-dir option."
-          $stderr.puts "Call 'annotate --help' for more info."
+          $stderr.puts "Call 'annotaterb --help' for more info."
           # exit 1 # TODO: Return exit code back to caller. Right now it messes up RSpec being able to run
         end
 
@@ -52,7 +52,7 @@ module AnnotateRb
 
           if model_files.size != specified_files.size
             $stderr.puts "The specified file could not be found in directory '#{options[:model_dir].join("', '")}'."
-            $stderr.puts "Call 'annotate --help' for more info."
+            $stderr.puts "Call 'annotaterb --help' for more info."
             # exit 1 # TODO: Return exit code back to caller. Right now it messes up RSpec being able to run
           end
 

--- a/lib/annotate_rb/model_annotator/model_files_getter.rb
+++ b/lib/annotate_rb/model_annotator/model_files_getter.rb
@@ -11,6 +11,8 @@ module AnnotateRb
         def call(options)
           model_files = []
 
+          # Note: This is currently broken as we don't set `is_rake` anywhere.
+          # It's an artifact from the old Annotate gem and how it did control flow.
           model_files = list_model_files_from_argument(options) if !options[:is_rake]
 
           return model_files if !model_files.empty?

--- a/lib/annotate_rb/model_annotator/related_files_list_builder.rb
+++ b/lib/annotate_rb/model_annotator/related_files_list_builder.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+module AnnotateRb
+  module ModelAnnotator
+    # Given a model file and options, this class will return a list of related files (e.g. fixture, controllers, etc)
+    # to also annotate
+    class RelatedFilesListBuilder
+      RELATED_TYPES = %w(test fixture factory serializer scaffold controller helper).freeze
+
+      def initialize(file, model_name, table_name, options)
+        @file = file
+        @model_name = model_name
+        @table_name = table_name
+        @options = options
+      end
+
+      def build
+        @list = []
+
+        add_related_test_files if !@options[:exclude_tests]
+        add_related_fixture_files if !@options[:exclude_fixtures]
+        add_related_factory_files if !@options[:exclude_factories]
+        add_related_serializer_files if !@options[:exclude_serializers]
+        add_related_scaffold_files if !@options[:exclude_scaffolds]
+        add_related_controller_files if !@options[:exclude_controllers]
+        add_related_helper_files if !@options[:exclude_helpers]
+        add_related_admin_files if !@options[:active_admin]
+        add_additional_file_patterns if !@options[:additional_file_patterns].present?
+
+        @list
+      end
+
+      private
+
+      def related_files_for_pattern(pattern_type)
+        patterns = PatternGetter.call(@options, pattern_type)
+
+        _related_files = patterns
+                          .map { |f| FileNameResolver.call(f, @model_name, @table_name) }
+                          .map { |f| Dir.glob(f) }
+                          .flatten
+
+        _related_files
+      end
+
+      def add_related_test_files
+        position_key = :position_in_test
+        pattern_type = 'test'
+
+        related_files = related_files_for_pattern(pattern_type)
+        files_with_position_key = related_files.map { |f| [f, position_key] }
+
+        @list.concat(files_with_position_key)
+      end
+
+      def add_related_fixture_files
+        position_key = :position_in_fixture
+        pattern_type = 'fixture'
+
+        related_files = related_files_for_pattern(pattern_type)
+        files_with_position_key = related_files.map { |f| [f, position_key] }
+
+        @list.concat(files_with_position_key)
+      end
+
+      def add_related_factory_files
+        position_key = :position_in_factory
+        pattern_type = 'factory'
+
+        related_files = related_files_for_pattern(pattern_type)
+        files_with_position_key = related_files.map { |f| [f, position_key] }
+
+        @list.concat(files_with_position_key)
+      end
+
+      def add_related_serializer_files
+        position_key = :position_in_serializer
+        pattern_type = 'serializer'
+
+        related_files = related_files_for_pattern(pattern_type)
+        files_with_position_key = related_files.map { |f| [f, position_key] }
+
+        @list.concat(files_with_position_key)
+      end
+
+      def add_related_scaffold_files
+        position_key = :position_in_scaffold # Key does not exist
+        pattern_type = 'scaffold'
+
+        related_files = related_files_for_pattern(pattern_type)
+        files_with_position_key = related_files.map { |f| [f, position_key] }
+
+        @list.concat(files_with_position_key)
+      end
+
+      def add_related_controller_files
+        position_key = :position_in_controller # Key does not exist
+        pattern_type = 'controller'
+
+        related_files = related_files_for_pattern(pattern_type)
+        files_with_position_key = related_files.map { |f| [f, position_key] }
+
+        @list.concat(files_with_position_key)
+      end
+
+      def add_related_helper_files
+        position_key = :position_in_helper # Key does not exist
+        pattern_type = 'helper'
+
+        related_files = related_files_for_pattern(pattern_type)
+        files_with_position_key = related_files.map { |f| [f, position_key] }
+
+        @list.concat(files_with_position_key)
+      end
+
+      def add_related_admin_files
+        position_key = :position_in_admin # Key does not exist
+        pattern_type = 'admin'
+
+        related_files = related_files_for_pattern(pattern_type)
+        files_with_position_key = related_files.map { |f| [f, position_key] }
+
+        @list.concat(files_with_position_key)
+      end
+
+      def add_additional_file_patterns
+        position_key = :position_in_additional_file_patterns # Key does not exist
+        pattern_type = 'additional_file_patterns'
+
+        related_files = related_files_for_pattern(pattern_type)
+        files_with_position_key = related_files.map { |f| [f, position_key] }
+
+        @list.concat(files_with_position_key)
+      end
+    end
+  end
+end

--- a/lib/annotate_rb/parser.rb
+++ b/lib/annotate_rb/parser.rb
@@ -156,13 +156,6 @@ module AnnotateRb
       option_parser.separator(' ' * 4 + 'Usage: annotaterb models [options]')
       option_parser.separator('')
 
-      # option_parser.on('-m',
-      #                  '--models',
-      #                  "Annotate ActiveRecord models") do
-      #   @options[:models] = true
-      #   @options[:command] = Commands::AnnotateModels.new
-      # end
-
       option_parser.on('-a',
                        '--active-admin',
                        'Annotate active_admin models') do
@@ -231,13 +224,6 @@ module AnnotateRb
       option_parser.separator('Annotate routes options:')
       option_parser.separator(' ' * 4 + 'Usage: annotaterb routes [options]')
       option_parser.separator('')
-
-      # option_parser.on('-r',
-      #                  '--routes',
-      #                  "Annotate routes.rb with the output of 'rails routes'") do
-      #   @options[:routes] = true
-      #   @options[:command] = Commands::AnnotateRoutes.new
-      # end
 
       option_parser.on('--ignore-routes REGEX',
                        "don't annotate routes that match a given REGEX (i.e., `annotate -I '(mobile|resque|pghero)'`") do |regex|

--- a/spec/lib/annotate_rb/annotate_models/annotate_models_annotating_a_file_frozen_spec.rb
+++ b/spec/lib/annotate_rb/annotate_models/annotate_models_annotating_a_file_frozen_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotator do
                             mock_column(:id, :integer),
                             mock_column(:name, :string, limit: 50)
                           ])
-      @schema_info = AnnotateRb::ModelAnnotator::AnnotationGenerator.new(@klass, '== Schema Info').generate
+      @schema_info = AnnotateRb::ModelAnnotator::AnnotationGenerator.new(@klass).generate
     end
 
     # TODO: Check out why this test fails due to test pollution
@@ -28,7 +28,11 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotator do
 
       it "should abort with different annotation when frozen: true " do
         annotate_one_file
-        another_schema_info = AnnotateRb::ModelAnnotator::AnnotationGenerator.new(mock_class(:users, :id, [mock_column(:id, :integer)]), '== Schema Info').generate
+
+        another_schema_info = AnnotateRb::ModelAnnotator::AnnotationGenerator.new(
+          mock_class(:users, :id, [mock_column(:id, :integer)]),
+        ).generate
+
         @schema_info = another_schema_info
 
         expect { annotate_one_file frozen: true }.to raise_error SystemExit, /user.rb needs to be updated, but annotate was run with `--frozen`./

--- a/spec/lib/annotate_rb/annotate_models/annotate_models_annotating_a_file_frozen_spec.rb
+++ b/spec/lib/annotate_rb/annotate_models/annotate_models_annotating_a_file_frozen_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotator do
     # TODO: Check out why this test fails due to test pollution
     describe 'frozen option' do
       it "should abort without existing annotation when frozen: true " do
-        expect { annotate_one_file frozen: true }.to raise_error SystemExit, /user.rb needs to be updated, but annotate was run with `--frozen`./
+        expect { annotate_one_file frozen: true }.to raise_error SystemExit, /user.rb needs to be updated, but annotaterb was run with `--frozen`./
       end
 
       it "should abort with different annotation when frozen: true " do
@@ -35,7 +35,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotator do
 
         @schema_info = another_schema_info
 
-        expect { annotate_one_file frozen: true }.to raise_error SystemExit, /user.rb needs to be updated, but annotate was run with `--frozen`./
+        expect { annotate_one_file frozen: true }.to raise_error SystemExit, /user.rb needs to be updated, but annotaterb was run with `--frozen`./
       end
 
       it "should NOT abort with same annotation when frozen: true " do

--- a/spec/lib/annotate_rb/annotate_models/annotate_models_annotating_a_file_spec.rb
+++ b/spec/lib/annotate_rb/annotate_models/annotate_models_annotating_a_file_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotator do
                             mock_column(:id, :integer),
                             mock_column(:name, :string, limit: 50)
                           ])
-      @schema_info = AnnotateRb::ModelAnnotator::AnnotationGenerator.new(@klass, '== Schema Info').generate
+      @schema_info = AnnotateRb::ModelAnnotator::AnnotationGenerator.new(@klass).generate
     end
 
     context "with 'before'" do
@@ -125,7 +125,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotator do
                                                 on_delete: :cascade)
                              ])
           @schema_info = AnnotateRb::ModelAnnotator::AnnotationGenerator.new(
-            klass, '== Schema Info', show_foreign_keys: true
+            klass, show_foreign_keys: true
           ).generate
 
           annotate_one_file
@@ -147,7 +147,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotator do
                                                 on_delete: :restrict)
                              ])
           @schema_info = AnnotateRb::ModelAnnotator::AnnotationGenerator.new(
-            klass, '== Schema Info', show_foreign_keys: true
+            klass, show_foreign_keys: true
           ).generate
 
           annotate_one_file
@@ -161,7 +161,6 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotator do
         annotate_one_file position: :before
         another_schema_info = AnnotateRb::ModelAnnotator::AnnotationGenerator.new(
           mock_class(:users, :id, [mock_column(:id, :integer)]),
-          '== Schema Info'
         ).generate
 
         @schema_info = another_schema_info
@@ -187,7 +186,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotator do
       before do
         annotate_one_file position: :after
         another_schema_info = AnnotateRb::ModelAnnotator::AnnotationGenerator.new(
-          mock_class(:users, :id, [mock_column(:id, :integer)]), '== Schema Info'
+          mock_class(:users, :id, [mock_column(:id, :integer)]),
         ).generate
 
         @schema_info = another_schema_info
@@ -211,7 +210,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotator do
 
     it 'should skip columns with option[:ignore_columns] set' do
       output = AnnotateRb::ModelAnnotator::AnnotationGenerator.new(
-        @klass, '== Schema Info', :ignore_columns => '(id|updated_at|created_at)'
+        @klass, :ignore_columns => '(id|updated_at|created_at)'
       ).generate
 
       expect(output.match(/id/)).to be_nil
@@ -230,7 +229,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotator do
                            mock_column(:name, :string, limit: 50)
                          ])
       schema_info = AnnotateRb::ModelAnnotator::AnnotationGenerator.new(
-        klass, '== Schema Info'
+        klass
       ).generate
 
       AnnotateRb::ModelAnnotator::FileAnnotator.call(model_file_name, schema_info, position: :before)
@@ -262,7 +261,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotator do
         model_file_name, = write_model 'user.rb', "#{magic_comment}\n#{content}"
 
         annotate_one_file position: :before
-        schema_info = AnnotateRb::ModelAnnotator::AnnotationGenerator.new(@klass, '== Schema Info').generate
+        schema_info = AnnotateRb::ModelAnnotator::AnnotationGenerator.new(@klass).generate
 
         expect(File.read(model_file_name)).to eq("#{magic_comment}\n\n#{schema_info}#{content}")
       end
@@ -271,7 +270,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotator do
     it 'only keeps a single empty line around the annotation (position :before)' do
       content = "class User < ActiveRecord::Base\nend\n"
       AnnotateTestConstants::MAGIC_COMMENTS.each do |magic_comment|
-        schema_info = AnnotateRb::ModelAnnotator::AnnotationGenerator.new(@klass, '== Schema Info').generate
+        schema_info = AnnotateRb::ModelAnnotator::AnnotationGenerator.new(@klass).generate
         model_file_name, = write_model 'user.rb', "#{magic_comment}\n\n\n\n#{content}"
 
         annotate_one_file position: :before
@@ -286,7 +285,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotator do
         model_file_name, = write_model 'user.rb', "#{magic_comment}\n#{content}"
 
         annotate_one_file position: :after
-        schema_info = AnnotateRb::ModelAnnotator::AnnotationGenerator.new(@klass, '== Schema Info').generate
+        schema_info = AnnotateRb::ModelAnnotator::AnnotationGenerator.new(@klass).generate
 
         expect(File.read(model_file_name)).to eq("#{magic_comment}\n#{content}\n#{schema_info}")
       end

--- a/spec/lib/annotate_rb/model_annotator/model_file_annotator_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/model_file_annotator_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe AnnotateRb::ModelAnnotator::ModelFileAnnotator do
   describe '.call' do
     subject do
-      described_class.call([], 'some_foo.rb', nil, options)
+      described_class.call([], 'some_foo.rb', options)
     end
 
     let(:options) { AnnotateRb::Options.from({ ignore_unknown_models: true }) }


### PR DESCRIPTION
* Refactors `ModelAnnotator` internals to (hopefully) improve maintainability
* Fixes bugs in old Annotate project that looked at wrong option keys for `excludes_*`