### PR TITLE
Support Sorbet `typed` magic comment

### DIFF
--- a/lib/annotate_rb/model_annotator/magic_comment_parser.rb
+++ b/lib/annotate_rb/model_annotator/magic_comment_parser.rb
@@ -10,7 +10,8 @@ module AnnotateRb
         HASH_FROZEN_STRING = Regexp.new(/(^#\s*frozen_string_literal:.+(?:\n|\r\n))/),
         STAR_ENCODING = Regexp.new(/(^# -\*- encoding\s?:.*(?:\n|\r\n))/),
         STAR_CODING = Regexp.new(/(^# -\*- coding:.*(?:\n|\r\n))/),
-        STAR_FROZEN_STRING = Regexp.new(/(^# -\*- frozen_string_literal\s*:.+-\*-(?:\n|\r\n))/)
+        STAR_FROZEN_STRING = Regexp.new(/(^# -\*- frozen_string_literal\s*:.+-\*-(?:\n|\r\n))/),
+        SORBET_TYPED_STRING = Regexp.new(/(^#\s*typed:.*(?:\n|r\n))/).freeze
       ].freeze
 
       MAGIC_COMMENTS_REGEX = Regexp.union(*MAGIC_COMMENTS).freeze

--- a/spec/lib/annotate_rb/model_annotator/magic_comment_parser_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/magic_comment_parser_spec.rb
@@ -180,5 +180,75 @@ RSpec.describe AnnotateRb::ModelAnnotator::MagicCommentParser do
 
       it { is_expected.to eq(expected) }
     end
+
+    context "model file with '# typed: ignore' magic comment" do
+      let(:magic_comment) { '# typed: ignore' }
+      let(:expected) { "#{magic_comment}\n" }
+      let(:content) do
+        <<~FILE
+          #{magic_comment}
+          class User < ApplicationRecord
+          end
+        FILE
+      end
+
+      it { is_expected.to eq(expected) }
+    end
+
+    context "model file with '# typed: false' magic comment" do
+      let(:magic_comment) { '# typed: false' }
+      let(:expected) { "#{magic_comment}\n" }
+      let(:content) do
+        <<~FILE
+          #{magic_comment}
+          class User < ApplicationRecord
+          end
+        FILE
+      end
+
+      it { is_expected.to eq(expected) }
+    end
+
+    context "model file with '# typed: true' magic comment" do
+      let(:magic_comment) { '# typed: true' }
+      let(:expected) { "#{magic_comment}\n" }
+      let(:content) do
+        <<~FILE
+          #{magic_comment}
+          class User < ApplicationRecord
+          end
+        FILE
+      end
+
+      it { is_expected.to eq(expected) }
+    end
+
+    context "model file with '# typed: strict' magic comment" do
+      let(:magic_comment) { '# typed: strict' }
+      let(:expected) { "#{magic_comment}\n" }
+      let(:content) do
+        <<~FILE
+          #{magic_comment}
+          class User < ApplicationRecord
+          end
+        FILE
+      end
+
+      it { is_expected.to eq(expected) }
+    end
+
+    context "model file with '# typed: strong' magic comment" do
+      let(:magic_comment) { '# typed: strong' }
+      let(:expected) { "#{magic_comment}\n" }
+      let(:content) do
+        <<~FILE
+          #{magic_comment}
+          class User < ApplicationRecord
+          end
+        FILE
+      end
+
+      it { is_expected.to eq(expected) }
+    end
   end
 end


### PR DESCRIPTION
Add (silent) support for Sorbet comments, `# typed: ...`.

From https://github.com/ctran/annotate_models/pull/966. Credit goes to @matteolc.