### PR TITLE
Change instances of `Options.from` => `Options.new` in tests

### DIFF
--- a/spec/lib/annotate_rb/model_annotator/annotation_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/annotation_builder_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
 
     context "when option is not present" do
       let :options do
-        AnnotateRb::Options.from({classified_sort: false})
+        AnnotateRb::Options.new({classified_sort: false})
       end
 
       context 'when header is "Schema Info"' do
@@ -270,7 +270,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
             context "when indexes exist" do
               context 'when option "show_indexes" is true' do
                 let :options do
-                  AnnotateRb::Options.from({simple_indexes: false, show_indexes: true})
+                  AnnotateRb::Options.new({simple_indexes: false, show_indexes: true})
                 end
 
                 context "when indexes are normal" do
@@ -471,7 +471,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
 
               context 'when option "show_indexes" is true and "simple_indexes" is true' do
                 let :options do
-                  AnnotateRb::Options.from({simple_indexes: true, show_indexes: true})
+                  AnnotateRb::Options.new({simple_indexes: true, show_indexes: true})
                 end
 
                 context "when indexes are normal" do
@@ -672,7 +672,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
 
               context 'when option "simple_indexes" is true' do
                 let :options do
-                  AnnotateRb::Options.from({simple_indexes: true, show_indexes: false})
+                  AnnotateRb::Options.new({simple_indexes: true, show_indexes: false})
                 end
 
                 context 'when one of indexes includes "orders" clause' do
@@ -744,7 +744,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
 
               context 'when option "simple_indexes" is true and "show_indexes" is true' do
                 let :options do
-                  AnnotateRb::Options.from({simple_indexes: true, show_indexes: true})
+                  AnnotateRb::Options.new({simple_indexes: true, show_indexes: true})
                 end
 
                 context 'when one of indexes includes "orders" clause' do
@@ -843,7 +843,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
 
               context 'when option "show_foreign_keys" is specified' do
                 let :options do
-                  AnnotateRb::Options.from({show_foreign_keys: true})
+                  AnnotateRb::Options.new({show_foreign_keys: true})
                 end
 
                 context "when foreign_keys does not have option" do
@@ -906,7 +906,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
 
               context 'when option "show_foreign_keys" and "show_complete_foreign_keys" are specified' do
                 let :options do
-                  AnnotateRb::Options.from({show_foreign_keys: true, show_complete_foreign_keys: true})
+                  AnnotateRb::Options.new({show_foreign_keys: true, show_complete_foreign_keys: true})
                 end
 
                 let :expected_result do
@@ -945,7 +945,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
 
               context 'when "hide_limit_column_types" is blank string' do
                 let :options do
-                  AnnotateRb::Options.from({classified_sort: false, hide_limit_column_types: ""})
+                  AnnotateRb::Options.new({classified_sort: false, hide_limit_column_types: ""})
                 end
 
                 let :expected_result do
@@ -969,7 +969,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
 
               context 'when "hide_limit_column_types" is "integer,boolean"' do
                 let :options do
-                  AnnotateRb::Options.from({classified_sort: false, hide_limit_column_types: "integer,boolean"})
+                  AnnotateRb::Options.new({classified_sort: false, hide_limit_column_types: "integer,boolean"})
                 end
 
                 let :expected_result do
@@ -993,7 +993,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
 
               context 'when "hide_limit_column_types" is "integer,boolean,string,text"' do
                 let :options do
-                  AnnotateRb::Options.from({classified_sort: false, hide_limit_column_types: "integer,boolean,string,text"})
+                  AnnotateRb::Options.new({classified_sort: false, hide_limit_column_types: "integer,boolean,string,text"})
                 end
 
                 let :expected_result do
@@ -1027,7 +1027,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
 
               context 'when "hide_default_column_types" is blank string' do
                 let :options do
-                  AnnotateRb::Options.from({classified_sort: false, hide_default_column_types: ""})
+                  AnnotateRb::Options.new({classified_sort: false, hide_default_column_types: ""})
                 end
 
                 let :expected_result do
@@ -1050,7 +1050,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
 
               context 'when "hide_default_column_types" is "skip"' do
                 let :options do
-                  AnnotateRb::Options.from({classified_sort: false, hide_default_column_types: "skip"})
+                  AnnotateRb::Options.new({classified_sort: false, hide_default_column_types: "skip"})
                 end
 
                 let :expected_result do
@@ -1073,7 +1073,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
 
               context 'when "hide_default_column_types" is "json"' do
                 let :options do
-                  AnnotateRb::Options.from({classified_sort: false, hide_default_column_types: "json"})
+                  AnnotateRb::Options.new({classified_sort: false, hide_default_column_types: "json"})
                 end
 
                 let :expected_result do
@@ -1106,7 +1106,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
 
               context 'when "classified_sort" is "yes"' do
                 let :options do
-                  AnnotateRb::Options.from({classified_sort: "yes"})
+                  AnnotateRb::Options.new({classified_sort: "yes"})
                 end
 
                 let :expected_result do
@@ -1131,7 +1131,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
             context 'when "with_comment" is specified in options' do
               context 'when "with_comment" is "yes"' do
                 let :options do
-                  AnnotateRb::Options.from({classified_sort: false, with_comment: "yes"})
+                  AnnotateRb::Options.new({classified_sort: false, with_comment: "yes"})
                 end
 
                 context "when columns have comments" do
@@ -1342,7 +1342,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
 
               context "when other option is not specified" do
                 let :options do
-                  AnnotateRb::Options.from({format_markdown: true})
+                  AnnotateRb::Options.new({format_markdown: true})
                 end
 
                 let :expected_result do
@@ -1368,7 +1368,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
 
               context 'when option "show_indexes" is true' do
                 let :options do
-                  AnnotateRb::Options.from({format_markdown: true, show_indexes: true})
+                  AnnotateRb::Options.new({format_markdown: true, show_indexes: true})
                 end
 
                 context "when indexes are normal" do
@@ -1563,7 +1563,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
 
               context 'when option "show_foreign_keys" is true' do
                 let :options do
-                  AnnotateRb::Options.from({format_markdown: true, show_foreign_keys: true})
+                  AnnotateRb::Options.new({format_markdown: true, show_foreign_keys: true})
                 end
 
                 let :columns do

--- a/spec/lib/annotate_rb/model_annotator/column_annotation/attributes_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/column_annotation/attributes_builder_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AttributesBuilder d
     subject { described_class.new(column, options, is_primary_key, column_indices).build }
 
     let(:column) {}
-    let(:options) { AnnotateRb::Options.from({}) }
+    let(:options) { AnnotateRb::Options.new({}) }
     let(:is_primary_key) {}
     let(:column_indices) {}
 
@@ -63,7 +63,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AttributesBuilder d
 
     context "when a column has an index and simple index option is on" do
       let(:is_primary_key) { true }
-      let(:options) { AnnotateRb::Options.from({simple_indexes: true}) }
+      let(:options) { AnnotateRb::Options.new({simple_indexes: true}) }
 
       context "with an id integer primary key column" do
         let(:column) { mock_column("id", :integer) }

--- a/spec/lib/annotate_rb/model_annotator/column_annotation/type_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/column_annotation/type_builder_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::TypeBuilder do
     subject { described_class.new(column, options).build }
 
     let(:column) {}
-    let(:options) { AnnotateRb::Options.from({}) }
+    let(:options) { AnnotateRb::Options.new({}) }
 
     context "with an integer column" do
       let(:column) { mock_column(:id, :integer) }
@@ -85,7 +85,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::TypeBuilder do
       context 'when "hide_limit_column_types" is blank string' do
         let(:column) { mock_column(:name, :string, limit: 50) }
         let(:options) do
-          AnnotateRb::Options.from({hide_limit_column_types: ""})
+          AnnotateRb::Options.new({hide_limit_column_types: ""})
         end
         let(:expected_result) { "string(50)" }
 
@@ -95,7 +95,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::TypeBuilder do
       context 'when "hide_limit_column_types" is "integer,boolean"' do
         let(:column) { mock_column(:name, :string, limit: 50) }
         let(:options) do
-          AnnotateRb::Options.from({hide_limit_column_types: "integer,boolean"})
+          AnnotateRb::Options.new({hide_limit_column_types: "integer,boolean"})
         end
         let(:expected_result) { "string(50)" }
 
@@ -105,7 +105,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::TypeBuilder do
       context 'when "hide_limit_column_types" is "integer,boolean,string,text"' do
         let(:column) { mock_column(:name, :string, limit: 50) }
         let(:options) do
-          AnnotateRb::Options.from({hide_limit_column_types: "integer,boolean,string,text"})
+          AnnotateRb::Options.new({hide_limit_column_types: "integer,boolean,string,text"})
         end
         let(:expected_result) { "string" }
 

--- a/spec/lib/annotate_rb/model_annotator/model_class_getter_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/model_class_getter_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::ModelClassGetter do
       create(filename, file_content, options)
     end
 
-    let(:options) { AnnotateRb::Options.from(base_options) }
+    let(:options) { AnnotateRb::Options.new(base_options) }
     let(:base_options) { {model_dir: [Dir.mktmpdir("annotate_models")]} }
     let :klass do
       model_dir_path = options[:model_dir][0]

--- a/spec/lib/annotate_rb/model_annotator/model_files_getter_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/model_files_getter_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::ModelFilesGetter do
       context "when the model files are not specified" do
         context "when no option is specified" do
           let(:base_options) { {model_dir: [model_dir]} }
-          let(:options) { AnnotateRb::Options.from(base_options) }
+          let(:options) { AnnotateRb::Options.new(base_options) }
 
           it "returns all model files under `model_dir` directory" do
             is_expected.to contain_exactly(
@@ -43,7 +43,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::ModelFilesGetter do
 
         context "when `ignore_model_sub_dir` option is enabled" do
           let(:base_options) { {model_dir: [model_dir], ignore_model_sub_dir: true} }
-          let(:options) { AnnotateRb::Options.from(base_options) }
+          let(:options) { AnnotateRb::Options.new(base_options) }
 
           it "returns model files just below `model_dir` directory" do
             is_expected.to contain_exactly([model_dir, "foo.rb"])
@@ -64,7 +64,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::ModelFilesGetter do
 
         context "when no option is specified" do
           let(:base_options) { {model_dir: [model_dir, additional_model_dir]} }
-          let(:options) { AnnotateRb::Options.from(base_options) }
+          let(:options) { AnnotateRb::Options.new(base_options) }
 
           context "when all the specified files are in `model_dir` directory" do
             it "returns specified files" do
@@ -77,7 +77,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::ModelFilesGetter do
 
           context "when a model file outside `model_dir` directory is specified" do
             let(:base_options) { {model_dir: [model_dir]} }
-            let(:options) { AnnotateRb::Options.from(base_options) }
+            let(:options) { AnnotateRb::Options.new(base_options) }
 
             it "writes to $stderr" do
               subject
@@ -88,7 +88,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::ModelFilesGetter do
 
         context "when `is_rake` option is enabled" do
           let(:base_options) { {model_dir: [model_dir], is_rake: true} }
-          let(:options) { AnnotateRb::Options.from(base_options) }
+          let(:options) { AnnotateRb::Options.new(base_options) }
 
           it "returns all model files under `model_dir` directory" do
             is_expected.to contain_exactly(
@@ -104,7 +104,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::ModelFilesGetter do
     context "when `model_dir` is invalid" do
       let(:model_dir) { "/not_exist_path" }
       let(:base_options) { {model_dir: [model_dir]} }
-      let(:options) { AnnotateRb::Options.from(base_options) }
+      let(:options) { AnnotateRb::Options.new(base_options) }
 
       it "writes to $stderr" do
         subject

--- a/spec/lib/annotate_rb/model_annotator/pattern_getter_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/pattern_getter_spec.rb
@@ -2,12 +2,14 @@ RSpec.describe AnnotateRb::ModelAnnotator::PatternGetter do
   describe ".call" do
     subject { described_class.call(options, pattern_type) }
 
-    let(:options) { AnnotateRb::Options.from(base_options) }
+    let(:options) { AnnotateRb::Options.new(base_options) }
 
     context 'when pattern_type is "additional_file_patterns"' do
       let(:pattern_type) { "additional_file_patterns" }
 
       context "when additional_file_patterns is specified in the options" do
+        let(:base_options) { {root_dir: [""], additional_file_patterns: additional_file_patterns} }
+
         let(:additional_file_patterns) do
           [
             "/%PLURALIZED_MODEL_NAME%/**/*.rb",
@@ -15,15 +17,13 @@ RSpec.describe AnnotateRb::ModelAnnotator::PatternGetter do
           ]
         end
 
-        let(:base_options) { {additional_file_patterns: additional_file_patterns} }
-
         it 'returns additional_file_patterns in the argument "options"' do
           is_expected.to eq(additional_file_patterns)
         end
       end
 
       context "when additional_file_patterns is not specified in the options" do
-        let(:base_options) { {} }
+        let(:base_options) { {root_dir: [""]} }
 
         it "returns an empty array" do
           is_expected.to eq([])
@@ -32,7 +32,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::PatternGetter do
     end
 
     context 'when pattern_type is "test"' do
-      let(:base_options) { {} }
+      let(:base_options) { {root_dir: [""]} }
       let(:pattern_type) { "test" }
 
       it "returns patterns of test files" do
@@ -45,7 +45,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::PatternGetter do
     end
 
     context 'when pattern_type is "fixture"' do
-      let(:base_options) { {} }
+      let(:base_options) { {root_dir: [""]} }
       let(:pattern_type) { "fixture" }
 
       it "returns patterns of fixture files" do
@@ -59,7 +59,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::PatternGetter do
     end
 
     context 'when pattern_type is "scaffold"' do
-      let(:base_options) { {} }
+      let(:base_options) { {root_dir: [""]} }
       let(:pattern_type) { "scaffold" }
 
       it "returns patterns of scaffold files" do
@@ -73,7 +73,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::PatternGetter do
     end
 
     context 'when pattern_type is "factory"' do
-      let(:base_options) { {} }
+      let(:base_options) { {root_dir: [""]} }
       let(:pattern_type) { "factory" }
 
       it "returns patterns of factory files" do
@@ -95,7 +95,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::PatternGetter do
     end
 
     context 'when pattern_type is "serializer"' do
-      let(:base_options) { {} }
+      let(:base_options) { {root_dir: [""]} }
       let(:pattern_type) { "serializer" }
 
       it "returns patterns of serializer files" do
@@ -108,7 +108,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::PatternGetter do
     end
 
     context 'when pattern_type is "controller"' do
-      let(:base_options) { {} }
+      let(:base_options) { {root_dir: [""]} }
       let(:pattern_type) { "controller" }
 
       it "returns patterns of controller files" do
@@ -119,7 +119,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::PatternGetter do
     end
 
     context 'when pattern_type is "admin"' do
-      let(:base_options) { {} }
+      let(:base_options) { {root_dir: [""]} }
       let(:pattern_type) { "admin" }
 
       it "returns both singular and pluralized model names" do
@@ -128,7 +128,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::PatternGetter do
     end
 
     context 'when pattern_type is "helper"' do
-      let(:base_options) { {} }
+      let(:base_options) { {root_dir: [""]} }
       let(:pattern_type) { "helper" }
 
       it "returns patterns of helper files" do

--- a/spec/lib/annotate_rb/model_annotator/single_file_annotation_remover_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/single_file_annotation_remover_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::SingleFileAnnotationRemover do
         EOS
       end
 
-      subject { described_class.call(path, AnnotateRb::Options.from({wrapper_open: "wrapper"})) }
+      subject { described_class.call(path, AnnotateRb::Options.new({wrapper_open: "wrapper"})) }
 
       it "removes annotation" do
         expect(file_content_after_removal).to eq expected_result
@@ -127,7 +127,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::SingleFileAnnotationRemover do
         EOS
       end
 
-      subject { described_class.call(path, AnnotateRb::Options.from({wrapper_open: "wrapper"})) }
+      subject { described_class.call(path, AnnotateRb::Options.new({wrapper_open: "wrapper"})) }
 
       it "removes annotation" do
         expect(file_content_after_removal).to eq expected_result
@@ -184,7 +184,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::SingleFileAnnotationRemover do
         EOS
       end
 
-      subject { described_class.call(path, AnnotateRb::Options.from({wrapper_close: "wrapper"})) }
+      subject { described_class.call(path, AnnotateRb::Options.new({wrapper_close: "wrapper"})) }
 
       it "removes annotation" do
         expect(file_content_after_removal).to eq expected_result

--- a/spec/lib/annotate_rb/model_annotator/single_file_annotator_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/single_file_annotator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::SingleFileAnnotator do
 
   describe ".call" do
     describe "annotating a file without annotations" do
-      let(:options) { AnnotateRb::Options.from({}) }
+      let(:options) { AnnotateRb::Options.new({}) }
       let(:schema_info) do
         <<~SCHEMA
           # == Schema Information
@@ -48,7 +48,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::SingleFileAnnotator do
     end
 
     describe "annotating a file with old annotations" do
-      let(:options) { AnnotateRb::Options.from({}) }
+      let(:options) { AnnotateRb::Options.new({}) }
       let(:schema_info) do
         <<~SCHEMA
           # == Schema Information
@@ -98,7 +98,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::SingleFileAnnotator do
     end
 
     describe "annotating a file with old annotations and magic comments" do
-      let(:options) { AnnotateRb::Options.from({}) }
+      let(:options) { AnnotateRb::Options.new({}) }
       let(:schema_info) do
         <<~SCHEMA
           # == Schema Information
@@ -152,7 +152,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::SingleFileAnnotator do
     end
 
     describe "annotating a file with existing column comments" do
-      let(:options) { AnnotateRb::Options.from({with_comment: true}) }
+      let(:options) { AnnotateRb::Options.new({with_comment: true}) }
       let(:schema_info) do
         <<~SCHEMA
           # == Schema Information

--- a/spec/support/annotate_test_helpers.rb
+++ b/spec/support/annotate_test_helpers.rb
@@ -2,6 +2,7 @@
 
 module AnnotateTestHelpers
   def annotate_one_file(options = {})
+    # Note: .from uses loads the defaults which can make it unclear what options are actually be loaded
     opts = AnnotateRb::Options.from(options)
 
     AnnotateRb::ModelAnnotator::SingleFileAnnotator.call(@model_file_name, @schema_info, :position_in_class, opts)


### PR DESCRIPTION
`Options.from(...)` combines the passed in options with the defaults which can hide the implicit options that gets passed around. This change will improve clarity and prevent gotchas due to implicit options in tests.