### PR TITLE
Specify `standard` gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :development, :test do
   gem "byebug"
   gem "guard-rspec", require: false
 
-  gem "standard"
+  gem "standard", "~> 1.29.0"
   gem "terminal-notifier-guard", require: false
 
   platforms :mri, :mingw do

--- a/lib/annotate_rb/model_annotator/magic_comment_parser.rb
+++ b/lib/annotate_rb/model_annotator/magic_comment_parser.rb
@@ -5,13 +5,13 @@ module AnnotateRb
     # Extracts magic comments strings and returns them
     class MagicCommentParser
       MAGIC_COMMENTS = [
-        HASH_ENCODING = Regexp.new(/(^#\s*encoding:.*(?:\n|r\n))/),
-        HASH_CODING = Regexp.new(/(^# coding:.*(?:\n|\r\n))/),
-        HASH_FROZEN_STRING = Regexp.new(/(^#\s*frozen_string_literal:.+(?:\n|\r\n))/),
-        STAR_ENCODING = Regexp.new(/(^# -\*- encoding\s?:.*(?:\n|\r\n))/),
-        STAR_CODING = Regexp.new(/(^# -\*- coding:.*(?:\n|\r\n))/),
-        STAR_FROZEN_STRING = Regexp.new(/(^# -\*- frozen_string_literal\s*:.+-\*-(?:\n|\r\n))/),
-        SORBET_TYPED_STRING = Regexp.new(/(^#\s*typed:.*(?:\n|r\n))/).freeze
+        HASH_ENCODING = /(^#\s*encoding:.*(?:\n|r\n))/,
+        HASH_CODING = /(^# coding:.*(?:\n|\r\n))/,
+        HASH_FROZEN_STRING = /(^#\s*frozen_string_literal:.+(?:\n|\r\n))/,
+        STAR_ENCODING = /(^# -\*- encoding\s?:.*(?:\n|\r\n))/,
+        STAR_CODING = /(^# -\*- coding:.*(?:\n|\r\n))/,
+        STAR_FROZEN_STRING = /(^# -\*- frozen_string_literal\s*:.+-\*-(?:\n|\r\n))/,
+        SORBET_TYPED_STRING = /(^#\s*typed:.*(?:\n|r\n))/.freeze
       ].freeze
 
       MAGIC_COMMENTS_REGEX = Regexp.union(*MAGIC_COMMENTS).freeze

--- a/lib/annotate_rb/route_annotator/helper.rb
+++ b/lib/annotate_rb/route_annotator/helper.rb
@@ -3,7 +3,7 @@
 module AnnotateRb
   module RouteAnnotator
     module Helper
-      MAGIC_COMMENT_MATCHER = Regexp.new(/(^#\s*encoding:.*)|(^# coding:.*)|(^# -\*- coding:.*)|(^# -\*- encoding\s?:.*)|(^#\s*frozen_string_literal:.+)|(^# -\*- frozen_string_literal\s*:.+-\*-)/).freeze
+      MAGIC_COMMENT_MATCHER = /(^#\s*encoding:.*)|(^# coding:.*)|(^# -\*- coding:.*)|(^# -\*- encoding\s?:.*)|(^#\s*frozen_string_literal:.+)|(^# -\*- frozen_string_literal\s*:.+-\*-)/.freeze
 
       class << self
         def routes_file_exist?


### PR DESCRIPTION
Adding constraint to the `standard` gem because we don't check in Gemfile.lock. Without this, CI and other people's environments can use differing versions of `standard`.