### PR TITLE
Add `ANNOTATERB_SKIP_ON_DB_TASKS` ENV var to skip auto annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ $ bin/rails g annotate_rb:install
 
 This will copy a rake task into your Rails project's `lib/tasks` directory that will hook into the Rails project rake tasks, automatically running AnnotateRb after database migration rake tasks.
 
+To skip the automatic annotation that happens after a db task, pass the environment variable `ANNOTATERB_SKIP_ON_DB_TASKS=1` before your command.
+
+```sh
+$ ANNOTATERB_SKIP_ON_DB_TASKS=1 bin/rails db:migrate
+```
+
 ## Migrating from the annotate gem
 Refer to the [migration guide](MIGRATION_GUIDE.md).
 

--- a/dummyapp/Gemfile.lock
+++ b/dummyapp/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    annotaterb (4.0.0)
+    annotaterb (4.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/dummyapp/db/schema.rb
+++ b/dummyapp/db/schema.rb
@@ -27,4 +27,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_11_202209) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
 end

--- a/dummyapp/lib/tasks/annotate_rb.rake
+++ b/dummyapp/lib/tasks/annotate_rb.rake
@@ -1,7 +1,7 @@
 # This rake task was added by annotate_rb gem.
 
 # Can set `ANNOTATERB_SKIP_ON_DB_TASKS` to be anything to skip this
-if Rails.env.development? && ENV['ANNOTATERB_SKIP_ON_DB_TASKS'].nil?
+if Rails.env.development? && ENV["ANNOTATERB_SKIP_ON_DB_TASKS"].nil?
   require "annotate_rb"
 
   AnnotateRb::Core.load_rake_tasks

--- a/dummyapp/lib/tasks/annotate_rb.rake
+++ b/dummyapp/lib/tasks/annotate_rb.rake
@@ -1,0 +1,8 @@
+# This rake task was added by annotate_rb gem.
+
+# Can set `ANNOTATERB_SKIP_ON_DB_TASKS` to be anything to skip this
+if Rails.env.development? && ENV['ANNOTATERB_SKIP_ON_DB_TASKS'].nil?
+  require "annotate_rb"
+
+  AnnotateRb::Core.load_rake_tasks
+end

--- a/lib/generators/annotate_rb/install/templates/annotate_rb.rake
+++ b/lib/generators/annotate_rb/install/templates/annotate_rb.rake
@@ -1,6 +1,7 @@
 # This rake task was added by annotate_rb gem.
 
-if Rails.env.development?
+# Can set `ANNOTATERB_SKIP_ON_DB_TASKS` to be anything to skip this
+if Rails.env.development? && ENV['ANNOTATERB_SKIP_ON_DB_TASKS'].nil?
   require "annotate_rb"
 
   AnnotateRb::Core.load_rake_tasks

--- a/lib/generators/annotate_rb/install/templates/annotate_rb.rake
+++ b/lib/generators/annotate_rb/install/templates/annotate_rb.rake
@@ -1,7 +1,7 @@
 # This rake task was added by annotate_rb gem.
 
 # Can set `ANNOTATERB_SKIP_ON_DB_TASKS` to be anything to skip this
-if Rails.env.development? && ENV['ANNOTATERB_SKIP_ON_DB_TASKS'].nil?
+if Rails.env.development? && ENV["ANNOTATERB_SKIP_ON_DB_TASKS"].nil?
   require "annotate_rb"
 
   AnnotateRb::Core.load_rake_tasks


### PR DESCRIPTION
In the old annotate gem, it used to be possible set `ANNOTATE_SKIP_ON_DB_MIGRATE` to `true|t|yes|y|1` to skip the automatic annotation that happens after a Rails db task is run (e.g. `bin/rails db:migrate`). Note that the automatic annotation would only happen if a user installed the rails plugin (done via `rails g annotate_rb:install`).

This behavior got removed when the dependency on ENV was removed. After some feedback, it seems like it's worth adding back to support special development setups or for checks in a CI pipeline.

Note: if you want the updated rake task, you'll have to rerun `rails g annotate_rb:install`.