### PR TITLE
Prettify column defaults

### DIFF
--- a/dummyapp/Gemfile.lock
+++ b/dummyapp/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    annotaterb (4.2.0)
+    annotaterb (4.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/dummyapp/app/models/case.rb
+++ b/dummyapp/app/models/case.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: cases
+#
+#  id               :integer          not null, primary key
+#  default_number   :integer          default(1)
+#  default_zero     :integer          default(0)
+#  is_default_false :boolean          default(FALSE)
+#  is_default_true  :boolean          default(TRUE)
+#  json_text_field  :text
+#  simple_bool      :boolean
+#  simple_int       :integer
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+class Case < ApplicationRecord
+  # Model file with fields to test annotations
+  serialize :json_text_field, JSON, default: {}
+end

--- a/dummyapp/app/models/task.rb
+++ b/dummyapp/app/models/task.rb
@@ -1,2 +1,13 @@
+# == Schema Information
+#
+# Table name: tasks
+#
+#  id         :integer          not null, primary key
+#  content    :string
+#  count      :integer
+#  status     :boolean
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class Task < ApplicationRecord
 end

--- a/dummyapp/app/models/user.rb
+++ b/dummyapp/app/models/user.rb
@@ -1,2 +1,14 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id         :integer          not null, primary key
+#  about      :text
+#  age        :integer
+#  first_name :string
+#  last_name  :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class User < ApplicationRecord
 end

--- a/dummyapp/db/migrate/20230613195631_create_cases.rb
+++ b/dummyapp/db/migrate/20230613195631_create_cases.rb
@@ -1,0 +1,8 @@
+class CreateCases < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cases do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/dummyapp/db/migrate/20230613195649_add_complex_cases_to_cases.rb
+++ b/dummyapp/db/migrate/20230613195649_add_complex_cases_to_cases.rb
@@ -1,0 +1,8 @@
+class AddComplexCasesToCases < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cases, :is_default_false, :boolean, default: false
+    add_column :cases, :is_default_true, :boolean, default: true
+    add_column :cases, :default_number, :integer, default: 1
+    add_column :cases, :default_zero, :integer, default: 0
+  end
+end

--- a/dummyapp/db/migrate/20230614220615_add_simple_int_field_to_tasks.rb
+++ b/dummyapp/db/migrate/20230614220615_add_simple_int_field_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddSimpleIntFieldToTasks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cases, :simple_int, :integer
+  end
+end

--- a/dummyapp/db/migrate/20230614220819_add_simple_bool_to_cases.rb
+++ b/dummyapp/db/migrate/20230614220819_add_simple_bool_to_cases.rb
@@ -1,0 +1,5 @@
+class AddSimpleBoolToCases < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cases, :simple_bool, :boolean
+  end
+end

--- a/dummyapp/db/migrate/20230614221012_add_json_text_field_to_cases.rb
+++ b/dummyapp/db/migrate/20230614221012_add_json_text_field_to_cases.rb
@@ -1,0 +1,5 @@
+class AddJsonTextFieldToCases < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cases, :json_text_field, :text
+  end
+end

--- a/dummyapp/db/schema.rb
+++ b/dummyapp/db/schema.rb
@@ -10,7 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_11_202209) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_14_221012) do
+  create_table "cases", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "is_default_false", default: false
+    t.boolean "is_default_true", default: true
+    t.integer "default_number", default: 1
+    t.integer "default_zero", default: 0
+    t.integer "simple_int"
+    t.boolean "simple_bool"
+    t.text "json_text_field"
+  end
+
   create_table "tasks", force: :cascade do |t|
     t.integer "count"
     t.boolean "status"

--- a/lib/annotate_rb/model_annotator/column_annotation/annotation_builder.rb
+++ b/lib/annotate_rb/model_annotator/column_annotation/annotation_builder.rb
@@ -21,9 +21,10 @@ module AnnotateRb
 
           table_indices = @model.retrieve_indexes_from_table
           column_indices = table_indices.select { |ind| ind.columns.include?(@column.name) }
+          column_defaults = @model.column_defaults
 
-          column_attributes = AttributesBuilder.new(@column, @options, is_primary_key, column_indices).build
-          formatted_column_type = TypeBuilder.new(@column, @options).build
+          column_attributes = AttributesBuilder.new(@column, @options, is_primary_key, column_indices, column_defaults).build
+          formatted_column_type = TypeBuilder.new(@column, @options, column_defaults).build
 
           col_name = if @model.with_comments? && @column.comment
             "#{@column.name}(#{@column.comment.gsub(/\n/, '\\n')})"

--- a/lib/annotate_rb/model_annotator/column_annotation/attributes_builder.rb
+++ b/lib/annotate_rb/model_annotator/column_annotation/attributes_builder.rb
@@ -7,8 +7,8 @@ module AnnotateRb
         # Don't show default value for these column types
         NO_DEFAULT_COL_TYPES = %w[json jsonb hstore].freeze
 
-        def initialize(column, options, is_primary_key, column_indices)
-          @column = ColumnWrapper.new(column)
+        def initialize(column, options, is_primary_key, column_indices, column_defaults)
+          @column = ColumnWrapper.new(column, column_defaults)
           @options = options
           @is_primary_key = is_primary_key
           @column_indices = column_indices
@@ -19,6 +19,8 @@ module AnnotateRb
         def build
           column_type = @column.column_type_string
           attrs = []
+
+          # require 'pry-byebug'; binding.pry
 
           unless @column.default.nil? || hide_default?
             schema_default = "default(#{@column.default_string})"

--- a/lib/annotate_rb/model_annotator/column_annotation/attributes_builder.rb
+++ b/lib/annotate_rb/model_annotator/column_annotation/attributes_builder.rb
@@ -20,9 +20,7 @@ module AnnotateRb
           column_type = @column.column_type_string
           attrs = []
 
-          # require 'pry-byebug'; binding.pry
-
-          unless @column.default.nil? || hide_default?
+          if !@column.raw_default.nil? && !hide_default?
             schema_default = "default(#{@column.default_string})"
 
             attrs << schema_default

--- a/lib/annotate_rb/model_annotator/column_annotation/column_wrapper.rb
+++ b/lib/annotate_rb/model_annotator/column_annotation/column_wrapper.rb
@@ -4,18 +4,21 @@ module AnnotateRb
   module ModelAnnotator
     module ColumnAnnotation
       class ColumnWrapper
-        def initialize(column)
+        def initialize(column, column_defaults)
           @column = column
+          @column_defaults = column_defaults
         end
 
         def default
-          # Note: Used to be klass.column_defaults[name], where name is the column name.
-          # Looks to be identical, but keeping note here in case there are differences.
-          _column_default = @column.default
+          @column_defaults[@column.name]
+
+          # # Note: Used to be klass.column_defaults[name], where name is the column name.
+          # # Looks to be identical, but keeping note here in case there are differences.
+          # _column_default = @column.default
         end
 
         def default_string
-          quote(@column.default)
+          quote(default)
         end
 
         def type
@@ -86,6 +89,7 @@ module AnnotateRb
         # Simple quoting for the default column value
         def quote(value)
           case value
+          # case value.class
           when NilClass then "NULL"
           when TrueClass then "TRUE"
           when FalseClass then "FALSE"

--- a/lib/annotate_rb/model_annotator/column_annotation/column_wrapper.rb
+++ b/lib/annotate_rb/model_annotator/column_annotation/column_wrapper.rb
@@ -9,12 +9,16 @@ module AnnotateRb
           @column_defaults = column_defaults
         end
 
-        def default
+        def raw_default
+          @column.default
+        end
+
+        def default_value
           @column_defaults[@column.name]
         end
 
         def default_string
-          quote(default)
+          quote(default_value)
         end
 
         def type
@@ -85,7 +89,6 @@ module AnnotateRb
         # Simple quoting for the default column value
         def quote(value)
           case value
-          # case value.class
           when NilClass then "NULL"
           when TrueClass then "TRUE"
           when FalseClass then "FALSE"

--- a/lib/annotate_rb/model_annotator/column_annotation/column_wrapper.rb
+++ b/lib/annotate_rb/model_annotator/column_annotation/column_wrapper.rb
@@ -11,10 +11,6 @@ module AnnotateRb
 
         def default
           @column_defaults[@column.name]
-
-          # # Note: Used to be klass.column_defaults[name], where name is the column name.
-          # # Looks to be identical, but keeping note here in case there are differences.
-          # _column_default = @column.default
         end
 
         def default_string

--- a/lib/annotate_rb/model_annotator/column_annotation/type_builder.rb
+++ b/lib/annotate_rb/model_annotator/column_annotation/type_builder.rb
@@ -8,8 +8,9 @@ module AnnotateRb
         # Example: show "integer" instead of "integer(4)"
         NO_LIMIT_COL_TYPES = %w[integer bigint boolean].freeze
 
-        def initialize(column, options)
-          @column = ColumnWrapper.new(column)
+        def initialize(column, options, column_defaults)
+          # Passing `column_defaults` for posterity, don't actually need it here since it's not used
+          @column = ColumnWrapper.new(column, column_defaults)
           @options = options
         end
 

--- a/lib/annotate_rb/model_annotator/model_wrapper.rb
+++ b/lib/annotate_rb/model_annotator/model_wrapper.rb
@@ -32,6 +32,10 @@ module AnnotateRb
           end
       end
 
+      def column_defaults
+        @column_defaults ||= @klass.column_defaults
+      end
+
       def connection
         @klass.connection
       end

--- a/lib/annotate_rb/model_annotator/model_wrapper.rb
+++ b/lib/annotate_rb/model_annotator/model_wrapper.rb
@@ -32,10 +32,6 @@ module AnnotateRb
           end
       end
 
-      def column_defaults
-        @column_defaults ||= @klass.column_defaults
-      end
-
       def connection
         @klass.connection
       end

--- a/spec/lib/annotate_rb/model_annotator/column_annotation/annotation_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/column_annotation/annotation_builder_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AnnotationBuilder d
             AnnotateRb::ModelAnnotator::ModelWrapper,
             primary_key: "id",
             retrieve_indexes_from_table: [],
-            with_comments?: false
+            with_comments?: false,
+            column_defaults: {}
           )
         end
         let(:expected_result) do
@@ -38,7 +39,8 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AnnotationBuilder d
             AnnotateRb::ModelAnnotator::ModelWrapper,
             primary_key: "something_else",
             retrieve_indexes_from_table: [],
-            with_comments?: false
+            with_comments?: false,
+            column_defaults: {}
           )
         end
         let(:expected_result) do
@@ -61,7 +63,8 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AnnotationBuilder d
             AnnotateRb::ModelAnnotator::ModelWrapper,
             primary_key: "something_else",
             retrieve_indexes_from_table: [],
-            with_comments?: true
+            with_comments?: true,
+            column_defaults: {}
           )
         end
         let(:expected_result) do
@@ -81,12 +84,14 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AnnotationBuilder d
 
       context "when the column is the primary key" do
         let(:column) { mock_column(:id, :integer) }
+        let(:column_defaults) { {} }
         let(:model) do
           instance_double(
             AnnotateRb::ModelAnnotator::ModelWrapper,
             primary_key: "id",
             retrieve_indexes_from_table: [],
-            with_comments?: false
+            with_comments?: false,
+            column_defaults: {}
           )
         end
 
@@ -105,12 +110,14 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AnnotationBuilder d
 
       context "when the column is not the primary key" do
         let(:column) { mock_column(:id, :integer) }
+        let(:column_defaults) { {} }
         let(:model) do
           instance_double(
             AnnotateRb::ModelAnnotator::ModelWrapper,
             primary_key: "something_else",
             retrieve_indexes_from_table: [],
-            with_comments?: false
+            with_comments?: false,
+            column_defaults: {}
           )
         end
         let(:expected_result) do
@@ -130,12 +137,14 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AnnotationBuilder d
         let(:max_size) { 20 }
 
         let(:column) { mock_column(:id, :integer, comment: "[is commented]") }
+        let(:column_defaults) { {} }
         let(:model) do
           instance_double(
             AnnotateRb::ModelAnnotator::ModelWrapper,
             primary_key: "something_else",
             retrieve_indexes_from_table: [],
-            with_comments?: true
+            with_comments?: true,
+            column_defaults: {}
           )
         end
         let(:expected_result) do
@@ -157,12 +166,14 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AnnotationBuilder d
 
       context "when the column is the primary key" do
         let(:column) { mock_column(:id, :integer) }
+        let(:column_defaults) { {} }
         let(:model) do
           instance_double(
             AnnotateRb::ModelAnnotator::ModelWrapper,
             primary_key: "id",
             retrieve_indexes_from_table: [],
-            with_comments?: false
+            with_comments?: false,
+            column_defaults: {}
           )
         end
 
@@ -182,12 +193,14 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AnnotationBuilder d
 
       context "when the column is not the primary key" do
         let(:column) { mock_column(:id, :integer) }
+        let(:column_defaults) { {} }
         let(:model) do
           instance_double(
             AnnotateRb::ModelAnnotator::ModelWrapper,
             primary_key: "something_else",
             retrieve_indexes_from_table: [],
-            with_comments?: false
+            with_comments?: false,
+            column_defaults: {}
           )
         end
         let(:expected_result) do
@@ -211,7 +224,8 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AnnotationBuilder d
             AnnotateRb::ModelAnnotator::ModelWrapper,
             primary_key: "something_else",
             retrieve_indexes_from_table: [],
-            with_comments?: true
+            with_comments?: true,
+            column_defaults: {}
           )
         end
         let(:expected_result) do
@@ -239,7 +253,8 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AnnotationBuilder d
             AnnotateRb::ModelAnnotator::ModelWrapper,
             primary_key: "id",
             retrieve_indexes_from_table: [],
-            with_comments?: false
+            with_comments?: false,
+            column_defaults: {}
           )
         end
 
@@ -263,7 +278,8 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AnnotationBuilder d
             AnnotateRb::ModelAnnotator::ModelWrapper,
             primary_key: "something_else",
             retrieve_indexes_from_table: [],
-            with_comments?: false
+            with_comments?: false,
+            column_defaults: {}
           )
         end
         let(:expected_result) do
@@ -286,7 +302,8 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AnnotationBuilder d
             AnnotateRb::ModelAnnotator::ModelWrapper,
             primary_key: "something_else",
             retrieve_indexes_from_table: [],
-            with_comments?: true
+            with_comments?: true,
+            column_defaults: {}
           )
         end
         let(:expected_result) do

--- a/spec/lib/annotate_rb/model_annotator/column_annotation/attributes_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/column_annotation/attributes_builder_spec.rb
@@ -83,9 +83,10 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AttributesBuilder d
       end
     end
 
-    context "when a column has a default integer value" do
+    context "column defaults in sqlite" do
+      # Mocked representations when using the sqlite adapter
       context "with an integer default value of 0" do
-        let(:column) { mock_column("amount", :integer, default: 0) }
+        let(:column) { mock_column("amount", :integer, default: "0") }
         let(:column_defaults) { {"amount" => 0} }
         let(:expected_result) { ["default(0)", "not null"] }
 
@@ -93,17 +94,23 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AttributesBuilder d
       end
 
       context "with an integer default value of 1" do
-        let(:column) { mock_column("amount", :integer, default: 1) }
+        let(:column) { mock_column("amount", :integer, default: "1") }
         let(:column_defaults) { {"amount" => 1} }
         let(:expected_result) { ["default(1)", "not null"] }
 
         it { is_expected.to match_array(expected_result) }
       end
-    end
 
-    context "when a column has a default boolean value" do
+      context "with an integer field without a default" do
+        let(:column) { mock_column("amount", :integer, default: nil) }
+        let(:column_defaults) { {"amount" => nil} }
+        let(:expected_result) { ["not null"] }
+
+        it { is_expected.to match_array(expected_result) }
+      end
+
       context "with default of false" do
-        let(:column) { mock_column("flag", :boolean, default: false) }
+        let(:column) { mock_column("flag", :boolean, default: "0") }
         let(:column_defaults) { {"flag" => false} }
         let(:expected_result) { ["default(FALSE)", "not null"] }
 
@@ -111,9 +118,119 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AttributesBuilder d
       end
 
       context "with default of true" do
-        let(:column) { mock_column("flag", :boolean, default: true) }
+        let(:column) { mock_column("flag", :boolean, default: "1") }
         let(:column_defaults) { {"flag" => true} }
         let(:expected_result) { ["default(TRUE)", "not null"] }
+
+        it { is_expected.to match_array(expected_result) }
+      end
+
+      context "with a boolean field without a default" do
+        let(:column) { mock_column("flag", :boolean, default: nil) }
+        let(:column_defaults) { {"flag" => nil} }
+        let(:expected_result) { ["not null"] }
+
+        it { is_expected.to match_array(expected_result) }
+      end
+    end
+
+    context "column defaults in mysql" do
+      # Mocked representations when using the mysql adapter
+      context "with an integer default value of 0" do
+        let(:column) { mock_column("amount", :integer, default: "0") }
+        let(:column_defaults) { {"amount" => 0} }
+        let(:expected_result) { ["default(0)", "not null"] }
+
+        it { is_expected.to match_array(expected_result) }
+      end
+
+      context "with an integer default value of 1" do
+        let(:column) { mock_column("amount", :integer, default: "1") }
+        let(:column_defaults) { {"amount" => 1} }
+        let(:expected_result) { ["default(1)", "not null"] }
+
+        it { is_expected.to match_array(expected_result) }
+      end
+
+      context "with an integer field without a default" do
+        let(:column) { mock_column("amount", :integer, default: nil) }
+        let(:column_defaults) { {"amount" => 0} }
+        let(:expected_result) { ["not null"] }
+
+        it { is_expected.to match_array(expected_result) }
+      end
+
+      context "with default of false" do
+        let(:column) { mock_column("flag", :boolean, default: "0") }
+        let(:column_defaults) { {"flag" => false} }
+        let(:expected_result) { ["default(FALSE)", "not null"] }
+
+        it { is_expected.to match_array(expected_result) }
+      end
+
+      context "with default of true" do
+        let(:column) { mock_column("flag", :boolean, default: "1") }
+        let(:column_defaults) { {"flag" => true} }
+        let(:expected_result) { ["default(TRUE)", "not null"] }
+
+        it { is_expected.to match_array(expected_result) }
+      end
+
+      context "with a boolean field without a default" do
+        let(:column) { mock_column("flag", :boolean, default: nil) }
+        let(:column_defaults) { {"flag" => nil} }
+        let(:expected_result) { ["not null"] }
+
+        it { is_expected.to match_array(expected_result) }
+      end
+    end
+
+    context "column defaults in postgres" do
+      # Mocked representations when using the postgresql adapter
+      context "with an integer default value of 0" do
+        let(:column) { mock_column("amount", :integer, default: "0") }
+        let(:column_defaults) { {"amount" => 0} }
+        let(:expected_result) { ["default(0)", "not null"] }
+
+        it { is_expected.to match_array(expected_result) }
+      end
+
+      context "with an integer default value of 1" do
+        let(:column) { mock_column("amount", :integer, default: "1") }
+        let(:column_defaults) { {"amount" => 1} }
+        let(:expected_result) { ["default(1)", "not null"] }
+
+        it { is_expected.to match_array(expected_result) }
+      end
+
+      context "with an integer field without a default" do
+        let(:column) { mock_column("amount", :integer, default: nil) }
+        let(:column_defaults) { {"amount" => nil} }
+        let(:expected_result) { ["not null"] }
+
+        it { is_expected.to match_array(expected_result) }
+      end
+
+      context "with default of false" do
+        let(:column) { mock_column("flag", :boolean, default: "0") }
+        let(:column_defaults) { {"flag" => false} }
+        let(:expected_result) { ["default(FALSE)", "not null"] }
+
+        it { is_expected.to match_array(expected_result) }
+      end
+
+      context "with default of true" do
+        let(:column) { mock_column("flag", :boolean, default: "1") }
+        let(:column_defaults) { {"flag" => true} }
+        let(:expected_result) { ["default(TRUE)", "not null"] }
+
+        it { is_expected.to match_array(expected_result) }
+      end
+
+      context "with a boolean field without a default" do
+        let(:column) { mock_column("flag", :boolean, default: nil) }
+        let(:column_defaults) { {"flag" => nil} }
+        let(:expected_result) { ["not null"] }
 
         it { is_expected.to match_array(expected_result) }
       end

--- a/spec/lib/annotate_rb/model_annotator/column_annotation/attributes_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/column_annotation/attributes_builder_spec.rb
@@ -79,5 +79,22 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AttributesBuilder d
         it { is_expected.to match_array(expected_result) }
       end
     end
+
+    context "when a column has a default integer value" do
+      context "with an id integer primary key column with an integer default" do
+        let(:column) { mock_column("amount", :integer, default: 0) }
+        let(:expected_result) { ["default(0)", "not null"] }
+
+        it { is_expected.to match_array(expected_result) }
+      end
+
+      context "with an id integer primary key column with an integer default as a string" do
+        # PostgreSQL adapter gives the default as a String
+        let(:column) { mock_column("amount", :integer, default: "0") }
+        let(:expected_result) { ['default("0")', "not null"] }
+
+        it { is_expected.to match_array(expected_result) }
+      end
+    end
   end
 end

--- a/spec/lib/annotate_rb/model_annotator/column_annotation/attributes_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/column_annotation/attributes_builder_spec.rb
@@ -4,9 +4,10 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AttributesBuilder d
   include AnnotateTestHelpers
 
   describe "#build" do
-    subject { described_class.new(column, options, is_primary_key, column_indices).build }
+    subject { described_class.new(column, options, is_primary_key, column_indices, column_defaults).build }
 
     let(:column) {}
+    let(:column_defaults) { {} }
     let(:options) { AnnotateRb::Options.new({}) }
     let(:is_primary_key) {}
     let(:column_indices) {}
@@ -15,35 +16,37 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AttributesBuilder d
       let(:is_primary_key) { false }
 
       context "when the column is normal" do
-        let(:column) { mock_column(:id, :integer) }
+        let(:column) { mock_column("id", :integer) }
         let(:expected_result) { ["not null"] }
 
         it { is_expected.to match_array(expected_result) }
       end
 
       context "when an enum column exists" do
-        let(:column) { mock_column(:name, :enum, limit: [:enum1, :enum2]) }
+        let(:column) { mock_column("name", :enum, limit: [:enum1, :enum2]) }
         let(:expected_result) { ["not null", "(enum1, enum2)"] }
 
         it { is_expected.to match_array(expected_result) }
       end
 
       context "when an unsigned columns exist" do
-        let(:column) { mock_column(:integer, :integer, unsigned?: true) }
+        let(:column) { mock_column("integer", :integer, unsigned?: true) }
         let(:expected_result) { ["unsigned", "not null"] }
 
         it { is_expected.to match_array(expected_result) }
       end
 
       context "when column is an integer with a default value" do
-        let(:column) { mock_column(:size, :integer, default: 20) }
+        let(:column) { mock_column("size", :integer, default: 20) }
+        let(:column_defaults) { {"size" => 20} }
         let(:expected_result) { ["default(20)", "not null"] }
 
         it { is_expected.to match_array(expected_result) }
       end
 
       context "when column is a boolean with a default value" do
-        let(:column) { mock_column(:flag, :boolean, default: false) }
+        let(:column) { mock_column("flag", :boolean, default: false) }
+        let(:column_defaults) { {"flag" => false} }
         let(:expected_result) { ["default(FALSE)", "not null"] }
 
         it { is_expected.to match_array(expected_result) }
@@ -54,7 +57,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AttributesBuilder d
       let(:is_primary_key) { true }
 
       context "with an id integer primary key column" do
-        let(:column) { mock_column(:id, :integer, limit: 8) }
+        let(:column) { mock_column("id", :integer, limit: 8) }
         let(:expected_result) { ["not null", "primary key"] }
 
         it { is_expected.to match_array(expected_result) }
@@ -81,34 +84,36 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AttributesBuilder d
     end
 
     context "when a column has a default integer value" do
-      context "with an id integer primary key column with an integer default" do
+      context "with an integer default value of 0" do
         let(:column) { mock_column("amount", :integer, default: 0) }
+        let(:column_defaults) { {"amount" => 0} }
         let(:expected_result) { ["default(0)", "not null"] }
 
         it { is_expected.to match_array(expected_result) }
       end
 
-      context "with an id integer primary key column with an integer default as a string" do
-        # PostgreSQL adapter gives the default as a String
-        let(:column) { mock_column("amount", :integer, default: "0") }
-        let(:expected_result) { ['default("0")', "not null"] }
+      context "with an integer default value of 1" do
+        let(:column) { mock_column("amount", :integer, default: 1) }
+        let(:column_defaults) { {"amount" => 1} }
+        let(:expected_result) { ["default(1)", "not null"] }
 
         it { is_expected.to match_array(expected_result) }
       end
     end
 
     context "when a column has a default boolean value" do
-      context "with an id integer primary key column with an integer default" do
-        let(:column) { mock_column(:flag, :boolean, default: false) }
+      context "with default of false" do
+        let(:column) { mock_column("flag", :boolean, default: false) }
+        let(:column_defaults) { {"flag" => false} }
         let(:expected_result) { ["default(FALSE)", "not null"] }
 
         it { is_expected.to match_array(expected_result) }
       end
 
-      context "with an id integer primary key column with an integer default as a string" do
-        # PostgreSQL adapter gives the default as a String
-        let(:column) { mock_column(:flag, :boolean, default: "false") }
-        let(:expected_result) { ['default("false")', "not null"] }
+      context "with default of true" do
+        let(:column) { mock_column("flag", :boolean, default: true) }
+        let(:column_defaults) { {"flag" => true} }
+        let(:expected_result) { ["default(TRUE)", "not null"] }
 
         it { is_expected.to match_array(expected_result) }
       end

--- a/spec/lib/annotate_rb/model_annotator/column_annotation/attributes_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/column_annotation/attributes_builder_spec.rb
@@ -96,5 +96,22 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AttributesBuilder d
         it { is_expected.to match_array(expected_result) }
       end
     end
+
+    context "when a column has a default boolean value" do
+      context "with an id integer primary key column with an integer default" do
+        let(:column) { mock_column(:flag, :boolean, default: false) }
+        let(:expected_result) { ["default(FALSE)", "not null"] }
+
+        it { is_expected.to match_array(expected_result) }
+      end
+
+      context "with an id integer primary key column with an integer default as a string" do
+        # PostgreSQL adapter gives the default as a String
+        let(:column) { mock_column(:flag, :boolean, default: "false") }
+        let(:expected_result) { ['default("false")', "not null"] }
+
+        it { is_expected.to match_array(expected_result) }
+      end
+    end
   end
 end

--- a/spec/lib/annotate_rb/model_annotator/column_annotation/column_wrapper_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/column_annotation/column_wrapper_spec.rb
@@ -4,8 +4,9 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::ColumnWrapper do
   include AnnotateTestHelpers
 
   describe "#default_string" do
-    subject { described_class.new(column).default_string }
-    let(:column) { mock_column(nil, nil, default: value) }
+    subject { described_class.new(column, column_defaults).default_string }
+    let(:column) { mock_column("field", nil, default: value) }
+    let(:column_defaults) { {"field" => value} }
 
     context "when the value is nil" do
       let(:value) { nil }

--- a/spec/lib/annotate_rb/model_annotator/column_annotation/type_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/column_annotation/type_builder_spec.rb
@@ -4,9 +4,10 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::TypeBuilder do
   include AnnotateTestHelpers
 
   describe "#build" do
-    subject { described_class.new(column, options).build }
+    subject { described_class.new(column, options, column_defaults).build }
 
     let(:column) {}
+    let(:column_defaults) { {} }
     let(:options) { AnnotateRb::Options.new({}) }
 
     before do
@@ -14,63 +15,63 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::TypeBuilder do
     end
 
     context "with an integer column" do
-      let(:column) { mock_column(:id, :integer) }
+      let(:column) { mock_column("id", :integer) }
       let(:expected_result) { "integer" }
 
       it { is_expected.to eq(expected_result) }
     end
 
     context "with a string column with a limit" do
-      let(:column) { mock_column(:name, :string, limit: 50) }
+      let(:column) { mock_column("name", :string, limit: 50) }
       let(:expected_result) { "string(50)" }
 
       it { is_expected.to eq(expected_result) }
     end
 
     context "with a text column with a limit" do
-      let(:column) { mock_column(:notes, :text, limit: 55) }
+      let(:column) { mock_column("notes", :text, limit: 55) }
       let(:expected_result) { "text(55)" }
 
       it { is_expected.to eq(expected_result) }
     end
 
     context "with a enum column" do
-      let(:column) { mock_column(:name, :enum, limit: [:enum1, :enum2]) }
+      let(:column) { mock_column("name", :enum, limit: [:enum1, :enum2]) }
       let(:expected_result) { "enum" }
 
       it { is_expected.to eq(expected_result) }
     end
 
     context "with a decimal column" do
-      let(:column) { mock_column(:decimal, :decimal, unsigned?: true, precision: 10, scale: 2) }
+      let(:column) { mock_column("decimal", :decimal, unsigned?: true, precision: 10, scale: 2) }
       let(:expected_result) { "decimal(10, 2)" }
 
       it { is_expected.to eq(expected_result) }
     end
 
     context "with a float column" do
-      let(:column) { mock_column(:float, :float, unsigned?: true) }
+      let(:column) { mock_column("float", :float, unsigned?: true) }
       let(:expected_result) { "float" }
 
       it { is_expected.to eq(expected_result) }
     end
 
     context "with a bigint column" do
-      let(:column) { mock_column(:bigint, :integer, unsigned?: true, bigint?: true) }
+      let(:column) { mock_column("bigint", :integer, unsigned?: true, bigint?: true) }
       let(:expected_result) { "bigint" }
 
       it { is_expected.to eq(expected_result) }
     end
 
     context "with a string column with a limit" do
-      let(:column) { mock_column(:name, :enum, limit: [:enum1, :enum2]) }
+      let(:column) { mock_column("name", :enum, limit: [:enum1, :enum2]) }
       let(:expected_result) { "enum" }
 
       it { is_expected.to eq(expected_result) }
     end
 
     context "with a boolean" do
-      let(:column) { mock_column(:flag, :boolean, default: false) }
+      let(:column) { mock_column("flag", :boolean, default: false) }
       let(:expected_result) { "boolean" }
 
       it { is_expected.to eq(expected_result) }
@@ -78,7 +79,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::TypeBuilder do
 
     context 'when "format_yard" is specified in options' do
       context "with a string column with a limit" do
-        let(:column) { mock_column(:name, :string, limit: 50) }
+        let(:column) { mock_column("name", :string, limit: 50) }
         let(:options) do
           AnnotateRb::Options.new({format_yard: true})
         end
@@ -90,7 +91,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::TypeBuilder do
 
     context 'when "hide_limit_column_types" is specified in options' do
       context 'when "hide_limit_column_types" is blank string' do
-        let(:column) { mock_column(:name, :string, limit: 50) }
+        let(:column) { mock_column("name", :string, limit: 50) }
         let(:options) do
           AnnotateRb::Options.new({hide_limit_column_types: ""})
         end
@@ -100,7 +101,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::TypeBuilder do
       end
 
       context 'when "hide_limit_column_types" is "integer,boolean"' do
-        let(:column) { mock_column(:name, :string, limit: 50) }
+        let(:column) { mock_column("name", :string, limit: 50) }
         let(:options) do
           AnnotateRb::Options.new({hide_limit_column_types: "integer,boolean"})
         end
@@ -110,7 +111,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::TypeBuilder do
       end
 
       context 'when "hide_limit_column_types" is "integer,boolean,string,text"' do
-        let(:column) { mock_column(:name, :string, limit: 50) }
+        let(:column) { mock_column("name", :string, limit: 50) }
         let(:options) do
           AnnotateRb::Options.new({hide_limit_column_types: "integer,boolean,string,text"})
         end


### PR DESCRIPTION
Fixes #45. 

When I extracted out column annotation building [1], I changed the way the default value was read. `Model#column_defaults` has the column default values that are casted appropriately, where as `Column#default` is uncasted and straight from the database, most of the time as a String. It's important to note that the various adapters (sqlite, mysql, postgres) implement the columns differently [2], especially as it relates to Column#default and Model#column_default values.

This PR restores parity with the original gem on how defaults are handled. It also adds tests for the various adapters, because the implementations vary under the hood.

As an example, the mysql adapter sets the value for an integer field without a default to be `0` in `Model#column_defaults`, where as sqlite and postgres set it to be `nil`.

[1] https://github.com/drwl/annotaterb/pull/28/files#diff-92c15977800c36cb911c1d7971ede0da49dae93b0c9e555777a5ca67ee81d93dR12-R14

[2] https://gist.github.com/drwl/ef274a763b773d132abfdb95d32347d2