### PR TITLE
Fix annotation for columns with `Date` and `DateTime` default values

### DIFF
--- a/lib/annotate_rb/model_annotator/column_annotation/default_value_builder.rb
+++ b/lib/annotate_rb/model_annotator/column_annotation/default_value_builder.rb
@@ -36,7 +36,7 @@ module AnnotateRb
           when BigDecimal then value.to_s("F")
           when String then value.inspect
           else
-            value.to_s
+            value.inspect
           end
         end
 

--- a/spec/lib/annotate_rb/model_annotator/column_annotation/default_value_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/column_annotation/default_value_builder_spec.rb
@@ -46,6 +46,18 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::DefaultValueBuilder
       it { is_expected.to eq("1.2") }
     end
 
+    context "when value is a Date" do
+      let(:value) { Date.new(2023, 9, 7) }
+
+      it { is_expected.to eq("Thu, 07 Sep 2023") }
+    end
+
+    context "when value is a DateTime" do
+      let(:value) { DateTime.new(2023, 9, 7) }
+
+      it { is_expected.to eq("Thu, 07 Sep 2023 00:00:00 +0000") }
+    end
+
     context "when value is an Array" do
       context "array is empty" do
         let(:value) { [] }
@@ -81,6 +93,18 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::DefaultValueBuilder
         let(:value) { [true, false] }
 
         it { is_expected.to eq("[TRUE, FALSE]") }
+      end
+
+      context "when value is a Date" do
+        let(:value) { [Date.new(2023, 9, 7)] }
+
+        it { is_expected.to eq("Thu, 07 Sep 2023") }
+      end
+
+      context "when value is a DateTime" do
+        let(:value) { [DateTime.new(2023, 9, 7)] }
+
+        it { is_expected.to eq("Thu, 07 Sep 2023 00:00:00 +0000") }
       end
     end
   end

--- a/spec/lib/annotate_rb/model_annotator/column_annotation/default_value_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/column_annotation/default_value_builder_spec.rb
@@ -46,18 +46,6 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::DefaultValueBuilder
       it { is_expected.to eq("1.2") }
     end
 
-    context "when value is a Date" do
-      let(:value) { Date.new(2023, 9, 7) }
-
-      it { is_expected.to eq("Thu, 07 Sep 2023") }
-    end
-
-    context "when value is a DateTime" do
-      let(:value) { DateTime.new(2023, 9, 7) }
-
-      it { is_expected.to eq("Thu, 07 Sep 2023 00:00:00 +0000") }
-    end
-
     context "when value is an Array" do
       context "array is empty" do
         let(:value) { [] }
@@ -93,18 +81,6 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::DefaultValueBuilder
         let(:value) { [true, false] }
 
         it { is_expected.to eq("[TRUE, FALSE]") }
-      end
-
-      context "when value is a Date" do
-        let(:value) { [Date.new(2023, 9, 7)] }
-
-        it { is_expected.to eq("Thu, 07 Sep 2023") }
-      end
-
-      context "when value is a DateTime" do
-        let(:value) { [DateTime.new(2023, 9, 7)] }
-
-        it { is_expected.to eq("Thu, 07 Sep 2023 00:00:00 +0000") }
       end
     end
   end


### PR DESCRIPTION
In https://github.com/drwl/annotaterb/pull/58, it changed the default behavior for unhandled types from `#inspect` to `#to_s`. I didn't consider to add test cases for dates or datetimes which led to a regression.

I tried writing unit tests for it, but realized that it wouldn't work easily because Rails monkey patches `#inspect`:

https://github.com/rails/rails/blob/44bd6e7acaa91dd59c260beea6863a49b84f6039/activesupport/lib/active_support/core_ext/date/conversions.rb#L63-L67

Testing this behavior will be handled in a separate PR.