### PR TITLE
Test running annotations after a migration

### DIFF
--- a/spec/integration/annotate_after_migration_spec.rb
+++ b/spec/integration/annotate_after_migration_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe "Annotate after running migrations", type: "aruba" do
     unset_bundler_env_vars
   end
 
+  after do
+    # Reset database schema after to avoid test pollution (for mysql and postgres)
+    _cmd = run_command_and_stop("bin/rails db:reset", fail_on_error: true, exit_timeout: command_timeout_seconds)
+  end
+
   let(:templates_dir) { File.join(aruba.config.root_directory, "spec/templates/#{ENV["DATABASE_ADAPTER"]}") }
   let(:migrations_templates_dir) { File.join(aruba.config.root_directory, "spec/templates/migrations") }
   let(:migration_file) { "20231013230731_add_int_field_to_test_defaults.rb" }

--- a/spec/integration/annotate_after_migration_spec.rb
+++ b/spec/integration/annotate_after_migration_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe "Annotate after running migrations", type: "aruba" do
   end
 
   after do
+    # Rollback copied migration to avoid test pollution (for mysql and postgres)
+    _cmd = run_command_and_stop("bin/rails db:rollback", fail_on_error: true, exit_timeout: command_timeout_seconds)
+
     dummy_app_migration_file = File.join("db/migrate", migration_file)
     # TODO: Look into Aruba cleaning the tmp working directory between tests since we copy the dummyapp every test
     remove(dummy_app_migration_file)
-
-    # Reset database schema without the added migration to avoid test pollution (for mysql and postgres)
-    _cmd = run_command_and_stop("bin/rails db:reset", fail_on_error: true, exit_timeout: command_timeout_seconds)
   end
 
   let(:templates_dir) { File.join(aruba.config.root_directory, "spec/templates/#{ENV["DATABASE_ADAPTER"]}") }

--- a/spec/integration/annotate_after_migration_spec.rb
+++ b/spec/integration/annotate_after_migration_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "integration_spec_helper"
+
+RSpec.describe "Annotate after running migrations", type: "aruba" do
+  let(:command_timeout_seconds) { 10 }
+
+  before do
+    copy(Dir[File.join(aruba.config.root_directory, "spec/dummyapp/*")], aruba.config.home_directory)
+
+    # Unset the bundler context from running annotaterb integration specs.
+    #   This way, when `run_command("bundle exec annotaterb")` runs, it runs as if it's within the context of dummyapp.
+    unset_bundler_env_vars
+  end
+
+  let(:templates_dir) { File.join(aruba.config.root_directory, "spec/templates/#{ENV["DATABASE_ADAPTER"]}") }
+  let(:migrations_templates_dir) { File.join(aruba.config.root_directory, "spec/templates/migrations") }
+  let(:migration_file) { "20231013230731_add_int_field_to_test_defaults.rb" }
+
+  let(:models_dir) { "app/models" }
+
+  it "adds annotations for the new field" do
+    expected_test_default = read(File.join(templates_dir, "test_default_updated.rb")).join("\n")
+    original_test_default = read(File.join(models_dir, "test_default.rb")).join("\n")
+
+    # Check that files have been copied over correctly
+    expect(expected_test_default).not_to eq(original_test_default)
+
+    copy(File.join(migrations_templates_dir, migration_file), "db/migrate")
+
+    _run_migrations_cmd = run_command_and_stop("bin/rails db:migrate", fail_on_error: true, exit_timeout: command_timeout_seconds)
+    _run_annotations_cmd = run_command_and_stop("bundle exec annotaterb models", fail_on_error: true, exit_timeout: command_timeout_seconds)
+
+    annotated_test_default = read(File.join(models_dir, "test_default.rb")).join("\n")
+
+    expect(last_command_started).to be_successfully_executed
+    expect(annotated_test_default).to eq(expected_test_default)
+  end
+end

--- a/spec/integration/annotate_after_migration_spec.rb
+++ b/spec/integration/annotate_after_migration_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe "Annotate after running migrations", type: "aruba" do
   end
 
   after do
-    # Reset database schema after to avoid test pollution (for mysql and postgres)
-    _cmd = run_command_and_stop("bin/rails db:reset", fail_on_error: true, exit_timeout: command_timeout_seconds)
-
     dummy_app_migration_file = File.join("db/migrate", migration_file)
     # TODO: Look into Aruba cleaning the tmp working directory between tests since we copy the dummyapp every test
     remove(dummy_app_migration_file)
+
+    # Reset database schema without the added migration to avoid test pollution (for mysql and postgres)
+    _cmd = run_command_and_stop("bin/rails db:reset", fail_on_error: true, exit_timeout: command_timeout_seconds)
   end
 
   let(:templates_dir) { File.join(aruba.config.root_directory, "spec/templates/#{ENV["DATABASE_ADAPTER"]}") }

--- a/spec/integration/annotate_after_migration_spec.rb
+++ b/spec/integration/annotate_after_migration_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe "Annotate after running migrations", type: "aruba" do
   after do
     # Reset database schema after to avoid test pollution (for mysql and postgres)
     _cmd = run_command_and_stop("bin/rails db:reset", fail_on_error: true, exit_timeout: command_timeout_seconds)
+
+    dummy_app_migration_file = File.join("db/migrate", migration_file)
+    # TODO: Look into Aruba cleaning the tmp working directory between tests since we copy the dummyapp every test
+    remove(dummy_app_migration_file)
   end
 
   let(:templates_dir) { File.join(aruba.config.root_directory, "spec/templates/#{ENV["DATABASE_ADAPTER"]}") }

--- a/spec/templates/migrations/20231013230731_add_int_field_to_test_defaults.rb
+++ b/spec/templates/migrations/20231013230731_add_int_field_to_test_defaults.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIntFieldToTestDefaults < ActiveRecord::Migration["#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}"]
+  def change
+    add_column :test_defaults, :int_field, :integer
+  end
+end

--- a/spec/templates/mysql2/test_default_updated.rb
+++ b/spec/templates/mysql2/test_default_updated.rb
@@ -4,15 +4,15 @@
 #
 # Table name: test_defaults
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  boolean    :boolean          default(FALSE)
 #  date       :date             default(Tue, 04 Jul 2023)
 #  datetime   :datetime         default(Tue, 04 Jul 2023 12:34:56.000000000 UTC +00:00)
 #  decimal    :decimal(14, 2)   default(43.21)
-#  float      :float            default(12.34)
+#  float      :float(24)        default(12.34)
 #  int_field  :integer
 #  integer    :integer          default(99)
-#  string     :string           default("hello world!")
+#  string     :string(255)      default("hello world!")
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #

--- a/spec/templates/mysql2/test_default_updated.rb
+++ b/spec/templates/mysql2/test_default_updated.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: test_defaults
+#
+#  id         :integer          not null, primary key
+#  boolean    :boolean          default(FALSE)
+#  date       :date             default(Tue, 04 Jul 2023)
+#  datetime   :datetime         default(Tue, 04 Jul 2023 12:34:56.000000000 UTC +00:00)
+#  decimal    :decimal(14, 2)   default(43.21)
+#  float      :float            default(12.34)
+#  int_field  :integer
+#  integer    :integer          default(99)
+#  string     :string           default("hello world!")
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class TestDefault < ApplicationRecord
+end

--- a/spec/templates/pg/test_default_updated.rb
+++ b/spec/templates/pg/test_default_updated.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: test_defaults
+#
+#  id         :integer          not null, primary key
+#  boolean    :boolean          default(FALSE)
+#  date       :date             default(Tue, 04 Jul 2023)
+#  datetime   :datetime         default(Tue, 04 Jul 2023 12:34:56.000000000 UTC +00:00)
+#  decimal    :decimal(14, 2)   default(43.21)
+#  float      :float            default(12.34)
+#  int_field  :integer
+#  integer    :integer          default(99)
+#  string     :string           default("hello world!")
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class TestDefault < ApplicationRecord
+end

--- a/spec/templates/pg/test_default_updated.rb
+++ b/spec/templates/pg/test_default_updated.rb
@@ -4,7 +4,7 @@
 #
 # Table name: test_defaults
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  boolean    :boolean          default(FALSE)
 #  date       :date             default(Tue, 04 Jul 2023)
 #  datetime   :datetime         default(Tue, 04 Jul 2023 12:34:56.000000000 UTC +00:00)

--- a/spec/templates/sqlite3/test_default_updated.rb
+++ b/spec/templates/sqlite3/test_default_updated.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: test_defaults
+#
+#  id         :integer          not null, primary key
+#  boolean    :boolean          default(FALSE)
+#  date       :date             default(Tue, 04 Jul 2023)
+#  datetime   :datetime         default(Tue, 04 Jul 2023 12:34:56.000000000 UTC +00:00)
+#  decimal    :decimal(14, 2)   default(43.21)
+#  float      :float            default(12.34)
+#  int_field  :integer
+#  integer    :integer          default(99)
+#  string     :string           default("hello world!")
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class TestDefault < ApplicationRecord
+end


### PR DESCRIPTION
This PR adds integration tests for running annotations after a migration:
- Tests manually running annotate models command after a migration
- Tests automatic annotations running after a database migration command