### PR TITLE
Add command to generate a configuration file

### DIFF
--- a/lib/annotate_rb.rb
+++ b/lib/annotate_rb.rb
@@ -22,6 +22,7 @@ require_relative "annotate_rb/eager_loader"
 require_relative "annotate_rb/rake_bootstrapper"
 require_relative "annotate_rb/config_finder"
 require_relative "annotate_rb/config_loader"
+require_relative "annotate_rb/config_generator"
 
 module AnnotateRb
 end

--- a/lib/annotate_rb/config_generator.rb
+++ b/lib/annotate_rb/config_generator.rb
@@ -3,12 +3,20 @@
 module AnnotateRb
   class ConfigGenerator
     class << self
-      # Adds unset configuration key-value pairs to the config file.
+      # Returns unset configuration key-value pairs as yaml.
       # Useful when a config file was generated an older version of gem and new
       #   settings get added.
       def unset_config_defaults
-        _user_defaults_hash = ConfigLoader.load_config
-        _defaults_hash = Options.from({}, {}).to_h
+        user_defaults = ConfigLoader.load_config
+        defaults = Options.from({}, {}).to_h
+
+        differences = defaults.keys - user_defaults.keys
+        result = defaults.slice(*differences)
+
+        # Generates proper YAML including the leading hyphens `---` header
+        yml_content = YAML.dump(result, StringIO.new).string
+        # Remove the header
+        yml_content.sub("---", "")
       end
 
       def default_config_yml

--- a/lib/annotate_rb/config_generator.rb
+++ b/lib/annotate_rb/config_generator.rb
@@ -4,19 +4,19 @@ module AnnotateRb
   class ConfigGenerator
     CONFIG_FILE = ConfigFinder::DOTFILE
 
-    def generate_using_defaults
-      defaults_hash = Options.from({}, {}).to_h
-      yml_content = YAML.dump(defaults_hash, StringIO.new).string
-      write_yml(CONFIG_FILE, yml_content)
-    end
+    class << self
+      # Adds unset configuration key-value pairs to the config file.
+      # Useful when a config file was generated an older version of gem and new
+      #   settings get added.
+      def unset_config_defaults
+        _user_defaults_hash = ConfigLoader.load_config
+        _defaults_hash = Options.from({}, {}).to_h
+      end
 
-    # Returns boolean if the config file exists or not
-    def config_file_exists?
-      File.exist?(CONFIG_FILE)
-    end
-
-    def write_yml(file_name, yml_content)
-      File.write(file_name, yml_content)
+      def default_config_yml
+        defaults_hash = Options.from({}, {}).to_h
+        _yml_content = YAML.dump(defaults_hash, StringIO.new).string
+      end
     end
   end
 end

--- a/lib/annotate_rb/config_generator.rb
+++ b/lib/annotate_rb/config_generator.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module AnnotateRb
+  class ConfigGenerator
+    CONFIG_FILE = ConfigFinder::DOTFILE
+
+    def generate_using_defaults
+      defaults_hash = Options.from({}, {}).to_h
+      yml_content = YAML.dump(defaults_hash, StringIO.new).string
+      write_yml(CONFIG_FILE, yml_content)
+    end
+
+    # Returns boolean if the config file exists or not
+    def config_file_exists?
+      File.exist?(CONFIG_FILE)
+    end
+
+    def write_yml(file_name, yml_content)
+      File.write(file_name, yml_content)
+    end
+  end
+end

--- a/lib/annotate_rb/config_generator.rb
+++ b/lib/annotate_rb/config_generator.rb
@@ -2,8 +2,6 @@
 
 module AnnotateRb
   class ConfigGenerator
-    CONFIG_FILE = ConfigFinder::DOTFILE
-
     class << self
       # Adds unset configuration key-value pairs to the config file.
       # Useful when a config file was generated an older version of gem and new

--- a/lib/generators/annotate_rb/config/USAGE
+++ b/lib/generators/annotate_rb/config/USAGE
@@ -1,0 +1,6 @@
+Description:
+    Generates a default configuration file, `.annotaterb.yml` in your
+    Rails app project root.
+
+Example:
+    `rails generate annotate_rb:config`

--- a/lib/generators/annotate_rb/config/config_generator.rb
+++ b/lib/generators/annotate_rb/config/config_generator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "annotate_rb"
+
+module AnnotateRb
+  module Generators
+    class ConfigGenerator < ::Rails::Generators::Base
+      def generate_config
+        create_file AnnotateRb::ConfigFinder::DOTFILE do
+          ConfigGenerator.default_config_yml
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/annotate_rb/config/config_generator.rb
+++ b/lib/generators/annotate_rb/config/config_generator.rb
@@ -6,8 +6,8 @@ module AnnotateRb
   module Generators
     class ConfigGenerator < ::Rails::Generators::Base
       def generate_config
-        create_file AnnotateRb::ConfigFinder::DOTFILE do
-          ConfigGenerator.default_config_yml
+        create_file ::AnnotateRb::ConfigFinder::DOTFILE do
+          ::AnnotateRb::ConfigGenerator.default_config_yml
         end
       end
     end

--- a/lib/generators/annotate_rb/hook/USAGE
+++ b/lib/generators/annotate_rb/hook/USAGE
@@ -1,0 +1,7 @@
+Description:
+    Adds a rake task into your Rails app's lib/tasks directory, that
+    automatically annotates models when you do a db:migrate in
+    development mode.
+
+Example:
+    `rails generate annotate_rb:hook`

--- a/lib/generators/annotate_rb/hook/hook_generator.rb
+++ b/lib/generators/annotate_rb/hook/hook_generator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "annotate_rb"
+
+module AnnotateRb
+  module Generators
+    class HookGenerator < ::Rails::Generators::Base
+      source_root File.expand_path("templates", __dir__)
+
+      def copy_hook_file
+        copy_file "annotate_rb.rake", "lib/tasks/annotate_rb.rake"
+      end
+    end
+  end
+end

--- a/lib/generators/annotate_rb/hook/templates/annotate_rb.rake
+++ b/lib/generators/annotate_rb/hook/templates/annotate_rb.rake
@@ -1,0 +1,8 @@
+# This rake task was added by annotate_rb gem.
+
+# Can set `ANNOTATERB_SKIP_ON_DB_TASKS` to be anything to skip this
+if Rails.env.development? && ENV["ANNOTATERB_SKIP_ON_DB_TASKS"].nil?
+  require "annotate_rb"
+
+  AnnotateRb::Core.load_rake_tasks
+end

--- a/lib/generators/annotate_rb/install/install_generator.rb
+++ b/lib/generators/annotate_rb/install/install_generator.rb
@@ -5,10 +5,9 @@ require "annotate_rb"
 module AnnotateRb
   module Generators
     class InstallGenerator < ::Rails::Generators::Base
-      source_root File.expand_path("templates", __dir__)
-
-      def copy_task
-        copy_file "annotate_rb.rake", "lib/tasks/annotate_rb.rake"
+      def install_hook_and_generate_defaults
+        generate "annotate_rb:hook"
+        generate "annotate_rb:config"
       end
     end
   end

--- a/lib/generators/annotate_rb/install/templates/annotate_rb.rake
+++ b/lib/generators/annotate_rb/install/templates/annotate_rb.rake
@@ -1,8 +1,0 @@
-# This rake task was added by annotate_rb gem.
-
-# Can set `ANNOTATERB_SKIP_ON_DB_TASKS` to be anything to skip this
-if Rails.env.development? && ENV["ANNOTATERB_SKIP_ON_DB_TASKS"].nil?
-  require "annotate_rb"
-
-  AnnotateRb::Core.load_rake_tasks
-end

--- a/lib/generators/annotate_rb/update_config/USAGE
+++ b/lib/generators/annotate_rb/update_config/USAGE
@@ -1,0 +1,6 @@
+Description:
+    Appends to .annotaterb.yml any missing default configuration
+    key-value pairs.
+
+Example:
+    `rails generate annotate_rb:update_config`

--- a/lib/generators/annotate_rb/update_config/update_config_generator.rb
+++ b/lib/generators/annotate_rb/update_config/update_config_generator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "annotate_rb"
+
+module AnnotateRb
+  module Generators
+    class UpdateConfigGenerator < ::Rails::Generators::Base
+      def generate_config
+        insert_into_file ::AnnotateRb::ConfigFinder::DOTFILE do
+          ::AnnotateRb::ConfigGenerator.unset_config_defaults
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/rails_generator_install_spec.rb
+++ b/spec/integration/rails_generator_install_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "Generator installs rake file", type: "aruba" do
 
   let(:rake_task_file) { "lib/tasks/annotate_rb.rake" }
   let(:rake_task) { File.join(aruba.config.root_directory, "lib/generators/annotate_rb/hook/templates/annotate_rb.rake") }
+  let(:config_file) { ".annotaterb.yml" }
 
   let(:generator_install_command) { "bin/rails generate annotate_rb:install" }
 
@@ -30,6 +31,17 @@ RSpec.describe "Generator installs rake file", type: "aruba" do
 
     expect(last_command_started).to be_successfully_executed
     expect(installed_rake_task).to eq(actual_rake_task)
+  end
+
+  it "generates a default config file" do
+    # First check that the file doesn't exist in dummyapp
+    expect(exist?(config_file)).to be_falsey
+
+    _cmd = run_command_and_stop(generator_install_command, fail_on_error: true, exit_timeout: command_timeout_seconds)
+
+    expect(exist?(config_file)).to be_truthy
+
+    expect(last_command_started).to be_successfully_executed
   end
 
   context "when the rake task already exists" do

--- a/spec/integration/rails_generator_install_spec.rb
+++ b/spec/integration/rails_generator_install_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Generator installs rake file", type: "aruba" do
   end
 
   let(:rake_task_file) { "lib/tasks/annotate_rb.rake" }
-  let(:rake_task) { File.join(aruba.config.root_directory, "lib/generators/annotate_rb/install/templates/annotate_rb.rake") }
+  let(:rake_task) { File.join(aruba.config.root_directory, "lib/generators/annotate_rb/hook/templates/annotate_rb.rake") }
 
   let(:generator_install_command) { "bin/rails generate annotate_rb:install" }
 

--- a/spec/integration/rails_generator_update_config_spec.rb
+++ b/spec/integration/rails_generator_update_config_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "integration_spec_helper"
+
+RSpec.describe "Generator appends to config file", type: "aruba" do
+  let(:command_timeout_seconds) { 10 }
+
+  before do
+    copy(Dir[File.join(aruba.config.root_directory, "spec/dummyapp/*")], aruba.config.home_directory)
+
+    # Unset the bundler context from running annotaterb integration specs.
+    #   This way, when `run_command("bundle exec annotaterb")` runs, it runs as if it's within the context of dummyapp.
+    unset_bundler_env_vars
+  end
+
+  let(:config_file) { ".annotaterb.yml" }
+  let(:config_file_content) do
+    <<~YML.strip
+      ---
+      :classified_sort: true
+      :exclude_controllers: true
+      :exclude_factories: false
+      :exclude_fixtures: false
+      :exclude_helpers: true
+      :exclude_scaffolds: true
+      :exclude_serializers: false
+      :exclude_sti_subclasses: false
+      :exclude_tests: false
+      :force: false
+      :format_markdown: false
+      :format_rdoc: false
+      :format_yard: false
+    YML
+  end
+
+  let(:generator_update_config_command) { "bin/rails generate annotate_rb:update_config" }
+
+  it "appends missing configuration key-value pairs" do
+    write_file(config_file, config_file_content)
+
+    _cmd = run_command_and_stop(generator_update_config_command, fail_on_error: true, exit_timeout: command_timeout_seconds)
+
+    changed_config_file = read(config_file).join("\n")
+
+    expect(last_command_started).to be_successfully_executed
+    expect(config_file_content).to eq(changed_config_file)
+  end
+end

--- a/spec/integration/rails_generator_update_config_spec.rb
+++ b/spec/integration/rails_generator_update_config_spec.rb
@@ -43,6 +43,6 @@ RSpec.describe "Generator appends to config file", type: "aruba" do
     changed_config_file = read(config_file).join("\n")
 
     expect(last_command_started).to be_successfully_executed
-    expect(config_file_content).to eq(changed_config_file)
+    expect(config_file_content).not_to eq(changed_config_file)
   end
 end

--- a/spec/lib/annotate_rb/config_generator_spec.rb
+++ b/spec/lib/annotate_rb/config_generator_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.describe AnnotateRb::ConfigGenerator do
+  describe "#generate_using_defaults" do
+    let(:klass) { described_class.new }
+    subject { klass.generate_using_defaults }
+
+    it "creates a config dotfile", :isolated_environment do
+      expect { subject }.to change { klass.config_file_exists? }.from(false).to(true)
+    end
+  end
+end

--- a/spec/lib/annotate_rb/config_generator_spec.rb
+++ b/spec/lib/annotate_rb/config_generator_spec.rb
@@ -1,12 +1,20 @@
 # frozen_string_literal: true
 
 RSpec.describe AnnotateRb::ConfigGenerator do
-  describe "#generate_using_defaults" do
-    let(:klass) { described_class.new }
-    subject { klass.generate_using_defaults }
+  describe "#default_config_yml" do
+    subject { described_class.default_config_yml }
 
-    it "creates a config dotfile", :isolated_environment do
-      expect { subject }.to change { klass.config_file_exists? }.from(false).to(true)
+    let(:example_config_pair) { {models: true} }
+
+    it "returns yml containing defaults" do
+      expect(subject).to be_a(String)
+
+      # Might be a better way to do this
+      parsed = YAML.safe_load(
+        subject, permitted_classes: [Regexp, Symbol], aliases: true, symbolize_names: true
+      )
+
+      expect(parsed).to include(**example_config_pair)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,4 +27,6 @@ RSpec.configure do |config|
   end
 
   config.order = :random
+
+  config.include_context "isolated environment", :isolated_environment
 end

--- a/spec/support/shared_contexts.rb
+++ b/spec/support/shared_contexts.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+RSpec.shared_context "isolated environment" do
+  # Taken from Rubocop's shared_contexts.rb
+  around do |example|
+    Dir.mktmpdir do |tmpdir|
+      # Make sure to expand all symlinks in the path first. Otherwise we may
+      # get mismatched pathnames when loading config files later on.
+      tmpdir = File.realpath(tmpdir)
+
+      working_dir = File.join(tmpdir, "work")
+      begin
+        FileUtils.mkdir_p(working_dir)
+
+        Dir.chdir(working_dir) { example.run }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR does the following:
- Adds 3 new rails generator commands: `bin/rails g annotate_rb:hook`, `bin/rails g annotate_rb:config`, and `bin/rails g annotate_rb:update_config`.
- Changes the behavior of the existing `bin/rails g annotate_rb:install` generator.

Previously, the install generator would only copy/install the hook rake file to the Rails project. With this change, it will also generate a default configuration file. 

`bin/rails g annotate_rb:hook`
(Only) adds the rake file to the Rails project.

`bin/rails g annotate_rb:config`
Generates a new configuration file, `.annotaterb.yml`, using defaults from the gem.

`bin/rails g annotate_rb:update_config`
Appends to `.annotaterb.yml` any configuration key-value pairs that are used by the Gem. This is useful when there's a drift between the config file values and the gem defaults (i.e. when new features get added).