### PR TITLE
Fix flakey integration test

### DIFF
--- a/spec/integration/rails_generator_install_spec.rb
+++ b/spec/integration/rails_generator_install_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "integration_spec_helper"
 
 RSpec.describe "Generator installs rake file", type: "aruba" do
@@ -47,6 +45,15 @@ RSpec.describe "Generator installs rake file", type: "aruba" do
 
       # TODO: Improve this so we don't have to rely on `exit_timeout`
       _cmd = run_command(generator_install_command, exit_timeout: 3)
+      # Because the rake task file already exists, there will be a conflict in the Rails generator.
+      # The prompt should look something like this:
+      #
+      # ...
+      #     generate  annotate_rb:hook
+      #        rails  generate annotate_rb:hook
+      #     conflict  lib/tasks/annotate_rb.rake
+      # Overwrite .../dummyapp/lib/tasks/annotate_rb.rake? (enter "h" for help) [Ynaqdhm]
+      type("q") # Quit the command
 
       # When the file already exists, the default behavior is the Thor CLI prompts user on how to proceed
       # https://github.com/rails/thor/blob/a4d99cfc97691504d26d0d0aefc649a8f2e89b3c/spec/actions/create_file_spec.rb#L112

--- a/spec/support/aruba.rb
+++ b/spec/support/aruba.rb
@@ -39,7 +39,7 @@ module SpecHelper
     end
 
     def reset_database
-      run_command_and_stop("bin/rails db:reset", fail_on_error: false, exit_timeout: 10)
+      run_command_and_stop("bin/rails db:drop db:create", fail_on_error: true, exit_timeout: 10)
     end
 
     def run_migrations

--- a/spec/support/aruba.rb
+++ b/spec/support/aruba.rb
@@ -34,8 +34,8 @@ module SpecHelper
     end
 
     def copy_dummy_app_into_aruba_working_directory
-      FileUtils.rm_rf(Dir.glob("#{aruba_working_directory}/*"))
-      FileUtils.cp_r(Dir.glob("#{dummy_app_directory}/*"), aruba_working_directory)
+      FileUtils.rm_rf(Dir.glob("#{aruba_working_directory}/**/*"))
+      FileUtils.cp_r(Dir.glob("#{dummy_app_directory}/."), aruba_working_directory)
     end
 
     def reset_database


### PR DESCRIPTION
This PR fixes the flakey test in `rails_generator_install_spec.rb`. Before this change, it seems like the `"returns the Thor cli"` test could have unexpected side effects because the `run_command` would not be resolved.

This PR:
- Quits the Thor CLI, aiming to resolve the command
- Changes the database reset command to have fresh databases without any chance of migrations being loaded before tests.