### PR TITLE
Support non-model files in `CustomParser`

### DIFF
--- a/lib/annotate_rb/model_annotator/file_parser/custom_parser.rb
+++ b/lib/annotate_rb/model_annotator/file_parser/custom_parser.rb
@@ -138,13 +138,8 @@ module AnnotateRb
         # ```
         def on_do_block(block_var, bodystmt)
           if block_var.blank? && bodystmt.blank?
-            _const, last_lineno = @block_ends.last
-
-            # Minor optimization, only add "end" when a closing block isn't added by #on_method_add_block
-            if last_lineno != lineno
-              @block_ends << ["end", lineno]
-              add_event(__method__, "end", lineno)
-            end
+            @block_ends << ["end", lineno]
+            add_event(__method__, "end", lineno)
           end
           super
         end

--- a/lib/annotate_rb/model_annotator/file_parser/custom_parser.rb
+++ b/lib/annotate_rb/model_annotator/file_parser/custom_parser.rb
@@ -11,7 +11,7 @@ module AnnotateRb
 
         class << self
           def parse(string)
-            _parser = new(string).tap(&:parse)
+            _parser = new(string, "", 0).tap(&:parse)
           end
         end
 

--- a/spec/lib/annotate_rb/model_annotator/annotated_file/generator_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/annotated_file/generator_spec.rb
@@ -400,5 +400,139 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotatedFile::Generator do
         end
       end
     end
+
+    context 'when position is "before" for a FactoryBot factory' do
+      let(:options) { AnnotateRb::Options.new({position_in_class: "before"}) }
+
+      let(:file_content) do
+        <<~FILE
+          FactoryBot.define do
+            factory :user do
+              admin { false }
+            end
+          end
+        FILE
+      end
+
+      let(:expected_content) do
+        <<~CONTENT
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id                     :bigint           not null, primary key
+          #
+          FactoryBot.define do
+            factory :user do
+              admin { false }
+            end
+          end
+        CONTENT
+      end
+
+      it "returns the annotated file content" do
+        is_expected.to eq(expected_content)
+      end
+    end
+
+    context 'when position is "after" for a FactoryBot factory' do
+      let(:options) { AnnotateRb::Options.new({position_in_class: "after"}) }
+
+      let(:file_content) do
+        <<~FILE
+          FactoryBot.define do
+            factory :user do
+              admin { false }
+            end
+          end
+        FILE
+      end
+
+      let(:expected_content) do
+        <<~CONTENT
+          FactoryBot.define do
+            factory :user do
+              admin { false }
+            end
+          end
+
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id                     :bigint           not null, primary key
+          #
+        CONTENT
+      end
+
+      it "returns the annotated file content" do
+        is_expected.to eq(expected_content)
+      end
+    end
+
+    context 'when position is "before" for a Fabrication fabricator' do
+      let(:options) { AnnotateRb::Options.new({position_in_class: "before"}) }
+
+      let(:file_content) do
+        <<~FILE
+          Fabricator(:user) do
+            name
+            reminder_at { 1.day.from_now.iso8601 }
+          end
+        FILE
+      end
+
+      let(:expected_content) do
+        <<~CONTENT
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id                     :bigint           not null, primary key
+          #
+          Fabricator(:user) do
+            name
+            reminder_at { 1.day.from_now.iso8601 }
+          end
+        CONTENT
+      end
+
+      it "returns the annotated file content" do
+        is_expected.to eq(expected_content)
+      end
+    end
+
+    context 'when position is "after" for a Fabrication fabricator' do
+      let(:options) { AnnotateRb::Options.new({position_in_class: "after"}) }
+
+      let(:file_content) do
+        <<~FILE
+          Fabricator(:user) do
+            name
+            reminder_at { 1.day.from_now.iso8601 }
+          end
+        FILE
+      end
+
+      let(:expected_content) do
+        <<~CONTENT
+          Fabricator(:user) do
+            name
+            reminder_at { 1.day.from_now.iso8601 }
+          end
+
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id                     :bigint           not null, primary key
+          #
+        CONTENT
+      end
+
+      it "returns the annotated file content" do
+        is_expected.to eq(expected_content)
+      end
+    end
   end
 end

--- a/spec/lib/annotate_rb/model_annotator/annotated_file/updater_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/annotated_file/updater_spec.rb
@@ -165,5 +165,123 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotatedFile::Updater do
         is_expected.to eq(expected_content)
       end
     end
+
+    context "when updating annotations for a FactoryBot factory" do
+      let(:file_content) do
+        <<~FILE
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id               :integer          not null, primary key
+          #
+          FactoryBot.define do
+            factory :user do
+              admin { false }
+            end
+          end
+        FILE
+      end
+      let(:new_annotations) do
+        <<~ANNOTATIONS
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id               :integer          not null, primary key
+          #  foreign_thing_id :integer          not null
+          #
+          # Foreign Keys
+          #
+          #  fk_rails_...  (foreign_thing_id => foreign_things.id) ON DELETE => cascade
+          #
+        ANNOTATIONS
+      end
+
+      let(:options) { AnnotateRb::Options.new({position_in_class: "before", show_foreign_keys: true}) }
+
+      let(:expected_content) do
+        <<~CONTENT
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id               :integer          not null, primary key
+          #  foreign_thing_id :integer          not null
+          #
+          # Foreign Keys
+          #
+          #  fk_rails_...  (foreign_thing_id => foreign_things.id) ON DELETE => cascade
+          #
+          FactoryBot.define do
+            factory :user do
+              admin { false }
+            end
+          end
+        CONTENT
+      end
+
+      it "returns the updated annotated file" do
+        is_expected.to eq(expected_content)
+      end
+    end
+
+    context "when updating annotations for a Fabrication fabricator" do
+      let(:file_content) do
+        <<~FILE
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id               :integer          not null, primary key
+          #
+          Fabricator(:user) do
+            name
+            reminder_at { 1.day.from_now.iso8601 }
+          end
+        FILE
+      end
+      let(:new_annotations) do
+        <<~ANNOTATIONS
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id               :integer          not null, primary key
+          #  foreign_thing_id :integer          not null
+          #
+          # Foreign Keys
+          #
+          #  fk_rails_...  (foreign_thing_id => foreign_things.id) ON DELETE => cascade
+          #
+        ANNOTATIONS
+      end
+
+      let(:options) { AnnotateRb::Options.new({position_in_class: "before", show_foreign_keys: true}) }
+
+      let(:expected_content) do
+        <<~CONTENT
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id               :integer          not null, primary key
+          #  foreign_thing_id :integer          not null
+          #
+          # Foreign Keys
+          #
+          #  fk_rails_...  (foreign_thing_id => foreign_things.id) ON DELETE => cascade
+          #
+          Fabricator(:user) do
+            name
+            reminder_at { 1.day.from_now.iso8601 }
+          end
+        CONTENT
+      end
+
+      it "returns the updated annotated file" do
+        is_expected.to eq(expected_content)
+      end
+    end
   end
 end

--- a/spec/lib/annotate_rb/model_annotator/custom_parser_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/custom_parser_spec.rb
@@ -10,7 +10,23 @@ RSpec.describe AnnotateRb::ModelAnnotator::FileParser::CustomParser do
       expect(subject.ends).to eq(expected_ends)
     end
 
-    context "when file body has single line comments" do
+    context "with a simple ActiveRecord model class" do
+      let(:input) do
+        <<~FILE
+          class User < ApplicationRecord
+          end
+        FILE
+      end
+      let(:expected_comments) { [] }
+      let(:expected_starts) { [["User", 1]] }
+      let(:expected_ends) { [["User", 2]] }
+
+      it "parses correctly" do
+        check_it_parses_correctly
+      end
+    end
+
+    context "with a simple ActiveRecord model class with comments" do
       let(:input) do
         <<~FILE
           # typed: strong
@@ -45,6 +61,24 @@ RSpec.describe AnnotateRb::ModelAnnotator::FileParser::CustomParser do
     end
 
     context "when class is namespaced in a module" do
+      let(:input) do
+        <<~FILE
+          module Admin
+            class User < ApplicationRecord
+            end
+          end
+        FILE
+      end
+      let(:expected_comments) { [] }
+      let(:expected_starts) { [["Admin", 1], ["User", 2]] }
+      let(:expected_ends) { [["User", 3], ["Admin", 4]] }
+
+      it "parses correctly" do
+        check_it_parses_correctly
+      end
+    end
+
+    context "when class is namespaced in a module with comments" do
       let(:input) do
         <<~FILE
           # typed: strong
@@ -115,24 +149,6 @@ RSpec.describe AnnotateRb::ModelAnnotator::FileParser::CustomParser do
       end
     end
 
-    context "when file body has no comments" do
-      let(:input) do
-        <<~FILE
-          class User < ApplicationRecord
-          end
-        FILE
-      end
-      let(:expected_comments) do
-        []
-      end
-      let(:expected_starts) { [["User", 1]] }
-      let(:expected_ends) { [["User", 2]] }
-
-      it "parses correctly" do
-        check_it_parses_correctly
-      end
-    end
-
     context "when class is defined on a namespace" do
       let(:input) do
         <<~FILE
@@ -140,11 +156,87 @@ RSpec.describe AnnotateRb::ModelAnnotator::FileParser::CustomParser do
           end
         FILE
       end
-      let(:expected_comments) do
-        []
-      end
+      let(:expected_comments) { [] }
       let(:expected_starts) { [["User", 1]] }
       let(:expected_ends) { [["Foo", 2]] }
+
+      it "parses correctly" do
+        check_it_parses_correctly
+      end
+    end
+
+    context "when using Fabrication fabricators" do
+      let(:input) do
+        <<~FILE
+          Fabricator(:bookmark) do
+            user
+            reminder_at { 1.day.from_now.iso8601 }
+          end
+        FILE
+      end
+      let(:expected_comments) { [] }
+      let(:expected_starts) { [["Fabricator", 1], ["reminder_at", 3]] }
+      let(:expected_ends) { [["reminder_at", 3], ["end", 4], ["Fabricator", 4]] }
+
+      it "parses correctly" do
+        check_it_parses_correctly
+      end
+    end
+
+    context "when using FactoryBot factories" do
+      let(:input) do
+        <<~FILE
+          FactoryBot.define do
+            factory :user do
+              admin { false }
+            end
+          end
+        FILE
+      end
+      let(:expected_comments) { [] }
+      let(:expected_starts) { [["FactoryBot", 1], ["factory", 2], ["admin", 3], ["factory", 4], ["FactoryBot", 5]] }
+      let(:expected_ends) { [["admin", 3], ["end", 4], ["end", 5]] }
+
+      it "parses correctly" do
+        check_it_parses_correctly
+      end
+    end
+
+    context "when using FactoryBot factories alias" do
+      let(:input) do
+        <<~FILE
+          factory :user, aliases: [:author, :commenter] do
+            first_name { "John" }
+            last_name { "Doe" }
+            date_of_birth { 18.years.ago }
+          end
+        FILE
+      end
+      let(:expected_comments) { [] }
+      let(:expected_starts) {
+        [["factory", 1], ["first_name", 2], ["last_name", 3], ["date_of_birth", 4], ["factory", 5]]
+      }
+      let(:expected_ends) { [["first_name", 2], ["last_name", 3], ["date_of_birth", 4], ["end", 5]] }
+
+      it "parses correctly" do
+        check_it_parses_correctly
+      end
+    end
+
+    context "when using FactoryBot factories alias with comments" do
+      let(:input) do
+        <<~FILE
+          # typed: strong
+          factory :user, aliases: [:author, :commenter] do
+            first_name { "John" }
+            last_name { "Doe" }
+            date_of_birth { 18.years.ago }
+          end
+        FILE
+      end
+      let(:expected_comments) { [["# typed: strong", 1]] }
+      let(:expected_starts) { [["factory", 2], ["first_name", 3], ["last_name", 4], ["date_of_birth", 5], ["factory", 6]] }
+      let(:expected_ends) { [["first_name", 3], ["last_name", 4], ["date_of_birth", 5], ["end", 6]] }
 
       it "parses correctly" do
         check_it_parses_correctly

--- a/spec/lib/annotate_rb/model_annotator/custom_parser_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/custom_parser_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe AnnotateRb::ModelAnnotator::FileParser::CustomParser do
         FILE
       end
       let(:expected_comments) { [] }
-      let(:expected_starts) { [["User", 1]] }
-      let(:expected_ends) { [["User", 2]] }
+      let(:expected_starts) { [["User", 0]] }
+      let(:expected_ends) { [["User", 1]] }
 
       it "parses correctly" do
         check_it_parses_correctly
@@ -43,17 +43,17 @@ RSpec.describe AnnotateRb::ModelAnnotator::FileParser::CustomParser do
       end
       let(:expected_comments) do
         [
-          ["# typed: strong", 1],
-          ["# == Schema Information", 3],
-          ["#", 4],
-          ["# Table name: users", 5],
-          ["#", 6],
-          ["#  id                     :bigint           not null, primary key", 7],
-          ["#", 8]
+          ["# typed: strong", 0],
+          ["# == Schema Information", 2],
+          ["#", 3],
+          ["# Table name: users", 4],
+          ["#", 5],
+          ["#  id                     :bigint           not null, primary key", 6],
+          ["#", 7]
         ]
       end
-      let(:expected_starts) { [["User", 9]] }
-      let(:expected_ends) { [["User", 10]] }
+      let(:expected_starts) { [["User", 8]] }
+      let(:expected_ends) { [["User", 9]] }
 
       it "parses correctly" do
         check_it_parses_correctly
@@ -70,8 +70,8 @@ RSpec.describe AnnotateRb::ModelAnnotator::FileParser::CustomParser do
         FILE
       end
       let(:expected_comments) { [] }
-      let(:expected_starts) { [["Admin", 1], ["User", 2]] }
-      let(:expected_ends) { [["User", 3], ["Admin", 4]] }
+      let(:expected_starts) { [["Admin", 0], ["User", 1]] }
+      let(:expected_ends) { [["User", 2], ["Admin", 3]] }
 
       it "parses correctly" do
         check_it_parses_correctly
@@ -97,17 +97,17 @@ RSpec.describe AnnotateRb::ModelAnnotator::FileParser::CustomParser do
       end
       let(:expected_comments) do
         [
-          ["# typed: strong", 1],
-          ["# == Schema Information", 3],
-          ["#", 4],
-          ["# Table name: users", 5],
-          ["#", 6],
-          ["#  id                     :bigint           not null, primary key", 7],
-          ["#", 8]
+          ["# typed: strong", 0],
+          ["# == Schema Information", 2],
+          ["#", 3],
+          ["# Table name: users", 4],
+          ["#", 5],
+          ["#  id                     :bigint           not null, primary key", 6],
+          ["#", 7]
         ]
       end
-      let(:expected_starts) { [["Admin", 9], ["User", 10]] }
-      let(:expected_ends) { [["User", 11], ["Admin", 12]] }
+      let(:expected_starts) { [["Admin", 8], ["User", 9]] }
+      let(:expected_ends) { [["User", 10], ["Admin", 11]] }
 
       it "parses correctly" do
         check_it_parses_correctly
@@ -132,17 +132,17 @@ RSpec.describe AnnotateRb::ModelAnnotator::FileParser::CustomParser do
       end
       let(:expected_comments) do
         [
-          ["=begin", 1],
-          ["This is", 2],
-          ["commented out", 3],
-          ["=end", 4],
-          ["=begin some_tag", 9],
-          ["this works, too", 10],
-          ["=end", 11]
+          ["=begin", 0],
+          ["This is", 1],
+          ["commented out", 2],
+          ["=end", 3],
+          ["=begin some_tag", 8],
+          ["this works, too", 9],
+          ["=end", 10]
         ]
       end
-      let(:expected_starts) { [["Foo", 6]] }
-      let(:expected_ends) { [["Foo", 7]] }
+      let(:expected_starts) { [["Foo", 5]] }
+      let(:expected_ends) { [["Foo", 6]] }
 
       it "parses correctly" do
         check_it_parses_correctly
@@ -157,8 +157,8 @@ RSpec.describe AnnotateRb::ModelAnnotator::FileParser::CustomParser do
         FILE
       end
       let(:expected_comments) { [] }
-      let(:expected_starts) { [["User", 1]] }
-      let(:expected_ends) { [["Foo", 2]] }
+      let(:expected_starts) { [["User", 0]] }
+      let(:expected_ends) { [["Foo", 1]] }
 
       it "parses correctly" do
         check_it_parses_correctly
@@ -175,8 +175,8 @@ RSpec.describe AnnotateRb::ModelAnnotator::FileParser::CustomParser do
         FILE
       end
       let(:expected_comments) { [] }
-      let(:expected_starts) { [["Fabricator", 1], ["reminder_at", 3]] }
-      let(:expected_ends) { [["reminder_at", 3], ["end", 4], ["Fabricator", 4]] }
+      let(:expected_starts) { [["Fabricator", 0], ["reminder_at", 2]] }
+      let(:expected_ends) { [["reminder_at", 2], ["end", 3], ["Fabricator", 3]] }
 
       it "parses correctly" do
         check_it_parses_correctly
@@ -194,8 +194,8 @@ RSpec.describe AnnotateRb::ModelAnnotator::FileParser::CustomParser do
         FILE
       end
       let(:expected_comments) { [] }
-      let(:expected_starts) { [["FactoryBot", 1], ["factory", 2], ["admin", 3], ["factory", 4], ["FactoryBot", 5]] }
-      let(:expected_ends) { [["admin", 3], ["end", 4], ["end", 5]] }
+      let(:expected_starts) { [["FactoryBot", 0], ["factory", 1], ["admin", 2], ["factory", 3], ["FactoryBot", 4]] }
+      let(:expected_ends) { [["admin", 2], ["end", 3], ["end", 4]] }
 
       it "parses correctly" do
         check_it_parses_correctly
@@ -214,9 +214,9 @@ RSpec.describe AnnotateRb::ModelAnnotator::FileParser::CustomParser do
       end
       let(:expected_comments) { [] }
       let(:expected_starts) {
-        [["factory", 1], ["first_name", 2], ["last_name", 3], ["date_of_birth", 4], ["factory", 5]]
+        [["factory", 0], ["first_name", 1], ["last_name", 2], ["date_of_birth", 3], ["factory", 4]]
       }
-      let(:expected_ends) { [["first_name", 2], ["last_name", 3], ["date_of_birth", 4], ["end", 5]] }
+      let(:expected_ends) { [["first_name", 1], ["last_name", 2], ["date_of_birth", 3], ["end", 4]] }
 
       it "parses correctly" do
         check_it_parses_correctly
@@ -234,9 +234,9 @@ RSpec.describe AnnotateRb::ModelAnnotator::FileParser::CustomParser do
           end
         FILE
       end
-      let(:expected_comments) { [["# typed: strong", 1]] }
-      let(:expected_starts) { [["factory", 2], ["first_name", 3], ["last_name", 4], ["date_of_birth", 5], ["factory", 6]] }
-      let(:expected_ends) { [["first_name", 3], ["last_name", 4], ["date_of_birth", 5], ["end", 6]] }
+      let(:expected_comments) { [["# typed: strong", 0]] }
+      let(:expected_starts) { [["factory", 1], ["first_name", 2], ["last_name", 3], ["date_of_birth", 4], ["factory", 5]] }
+      let(:expected_ends) { [["first_name", 2], ["last_name", 3], ["date_of_birth", 4], ["end", 5]] }
 
       it "parses correctly" do
         check_it_parses_correctly
@@ -265,21 +265,21 @@ RSpec.describe AnnotateRb::ModelAnnotator::FileParser::CustomParser do
       end
       let(:expected_comments) do
         [
-          ["# typed: strong", 1],
-          ["=begin", 3],
-          ["first line", 4],
-          ["second line", 5],
-          ["=end", 6],
-          ["# == Schema Information", 8],
-          ["#", 9],
-          ["# Table name: users", 10],
-          ["#", 11],
-          ["#  id                     :bigint           not null, primary key", 12],
-          ["#", 13]
+          ["# typed: strong", 0],
+          ["=begin", 2],
+          ["first line", 3],
+          ["second line", 4],
+          ["=end", 5],
+          ["# == Schema Information", 7],
+          ["#", 8],
+          ["# Table name: users", 9],
+          ["#", 10],
+          ["#  id                     :bigint           not null, primary key", 11],
+          ["#", 12]
         ]
       end
-      let(:expected_starts) { [["User", 14]] }
-      let(:expected_ends) { [["User", 15]] }
+      let(:expected_starts) { [["User", 13]] }
+      let(:expected_ends) { [["User", 14]] }
 
       it "parses correctly" do
         check_it_parses_correctly


### PR DESCRIPTION
This PR adds support for other Ruby files types that should be able to get model annotations added to them (i.e. factories, fabricators, etc).

In #72, AnnotateRb was changed to use `FileParser::CustomParser` to parse Ruby files instead of relying on regexes. That PR only added support for model files that used either `module Namespace...` or `class ModelName...` as the first line of Ruby. The parser did not have support for other file structures like FactoryBot factories or Fabrication fabricators. 

There may be other Ruby files that have code that is not currently handled by `CustomParser`, so those will have to be added in the future.