### PR TITLE
Add support for model name without namespace in resolver

### DIFF
--- a/lib/annotate_rb/model_annotator/file_name_resolver.rb
+++ b/lib/annotate_rb/model_annotator/file_name_resolver.rb
@@ -5,8 +5,13 @@ module AnnotateRb
     class FileNameResolver
       class << self
         def call(filename_template, model_name, table_name)
+          # e.g. with a model file name like "app/models/collapsed/example/test_model.rb"
+          # and using a collapsed `model_name` such as "collapsed/test_model"
+          model_name_without_namespace = model_name.split("/").last
+
           filename_template
             .gsub("%MODEL_NAME%", model_name)
+            .gsub("%MODEL_NAME_WITHOUT_NS%", model_name_without_namespace)
             .gsub("%PLURALIZED_MODEL_NAME%", model_name.pluralize)
             .gsub("%TABLE_NAME%", table_name || model_name.pluralize)
         end

--- a/spec/lib/annotate_rb/model_annotator/file_name_resolver_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/file_name_resolver_spec.rb
@@ -53,5 +53,18 @@ RSpec.describe AnnotateRb::ModelAnnotator::FileNameResolver do
         end
       end
     end
+
+    context 'When model_name is "collapsed/test_model" and table_name is "collapsed_test_model"' do
+      let(:model_name) { "collapsed/test_model" }
+      let(:table_name) { "collapsed_test_models" }
+
+      context "when filename_template is 'spec/models/collapsed/example/%MODEL_NAME_WITHOUT_NS%_spec.rb'" do
+        let(:filename_template) { "spec/models/collapsed/example/%MODEL_NAME_WITHOUT_NS%_spec.rb" }
+
+        it "returns the custom spec path for a collapsed model" do
+          is_expected.to eq "spec/models/collapsed/example/test_model_spec.rb"
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds a new wildcard that can be used in the `additional_file_patterns` options. When specifying additional files to get annotated, such as in tests or specs, you can use  `%MODEL_NAME_WITHOUT_NS%` as a wild card.

Example:
```yaml
:additional_file_patterns:
  - spec/components/%MODEL_NAME_WITHOUT_NS%_spec.rb
```