### PR TITLE
Memoize ActiveRecord migrator version calls

### DIFF
--- a/lib/annotate_rb/model_annotator/annotation_builder.rb
+++ b/lib/annotate_rb/model_annotator/annotation_builder.rb
@@ -56,11 +56,18 @@ module AnnotateRb
       def header
         header = @options[:format_markdown] ? PREFIX_MD.dup : PREFIX.dup
         header = "# #{header}"
-        version = begin
-          ActiveRecord::Migrator.current_version
-        rescue
-          0
+
+        if @options.get_state(:current_version).nil?
+          migration_version = begin
+            ActiveRecord::Migrator.current_version
+          rescue
+            0
+          end
+
+          @options.set_state(:current_version, migration_version)
         end
+
+        version = @options.get_state(:current_version)
 
         if @options[:include_version] && version > 0
           header += "\n# Schema version: #{version}"

--- a/spec/lib/annotate_rb/model_annotator/annotation_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/annotation_builder_spec.rb
@@ -1481,7 +1481,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
       end
 
       let :options do
-        {format_rdoc: true}
+        AnnotateRb::Options.new({format_rdoc: true})
       end
 
       let :columns do
@@ -1516,7 +1516,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
       end
 
       let :options do
-        {format_yard: true}
+        AnnotateRb::Options.new({format_yard: true})
       end
 
       let :columns do
@@ -1851,7 +1851,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
       end
 
       let :options do
-        {format_rdoc: true, with_comment: true, with_column_comments: true}
+        AnnotateRb::Options.new({format_rdoc: true, with_comment: true, with_column_comments: true})
       end
 
       let :columns do
@@ -1899,7 +1899,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
       end
 
       let :options do
-        {format_markdown: true, with_comment: true, with_column_comments: true}
+        AnnotateRb::Options.new({format_markdown: true, with_comment: true, with_column_comments: true})
       end
 
       let :columns do
@@ -1986,7 +1986,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
       end
 
       let :options do
-        {show_check_constraints: true}
+        AnnotateRb::Options.new({show_check_constraints: true})
       end
 
       let :columns do
@@ -2018,7 +2018,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
 
       context "when option is set to false" do
         let(:options) do
-          {show_check_constraints: false}
+          AnnotateRb::Options.new({show_check_constraints: false})
         end
 
         let :expected_result do


### PR DESCRIPTION
This PR memoizes the `ActiveRecord::Migrator.current_version` call so that it's only called once per annotaterb run. 

Prior to this change, there would be duplicate separate calls for each model that was being annotated.