### PR TITLE
Change AnnotationDecider to return false early

### DIFF
--- a/lib/annotate_rb/model_annotator/annotation_decider.rb
+++ b/lib/annotate_rb/model_annotator/annotation_decider.rb
@@ -18,6 +18,10 @@ module AnnotateRb
           klass = ModelClassGetter.call(@file, @options)
 
           klass_is_a_class = klass.is_a?(Class)
+          # Methods such as #superclass only exist on a class. Because of how the code is structured, `klass` could be a
+          #  module that does not support the #superclass method, so we want to return early.
+          return false if !klass_is_a_class
+
           klass_inherits_active_record_base = klass < ActiveRecord::Base
           klass_is_not_abstract = klass.respond_to?(:abstract_class) && !klass.abstract_class?
           klass_table_exists = klass.respond_to?(:abstract_class) && klass.table_exists?


### PR DESCRIPTION
In the old gem [1], the conditional for deciding to annotate a file was chained, meaning that execution of further checks stopped upon reaching a false condition. 

The conditional was hard to read, so I decomposed the conditional into readable chunks. This led to a regression, that deciding to annotate a `Module` would raise because `#superclass` is a method on classes, but not for instances of modules. By returning false early, we fix the regression.

To illustrate, before this change one would see this in the output:

```
Unable to process app/models/user_settings/dsl.rb: undefined method `superclass' for module UserSettings::DSL
```

when attempting to annotate a file like:
```ruby
# app/models/user_settings/dsl.rb

module UserSettings::DSL
  module ClassMethods
    # ... methods ...
  end
end
```

In the old gem, this error message wouldn't be outputted, so this change makes AnnotateRb match the behavior.

[1] https://github.com/ctran/annotate_models/blob/e60a66644e8a8ea5dccd6a398d31f22878233998/lib/annotate/annotate_models.rb#L734-L738