### PR TITLE
Add support for `NOT VALID` constraints

### DIFF
--- a/lib/annotate_rb/model_annotator/check_constraint_annotation/annotation_builder.rb
+++ b/lib/annotate_rb/model_annotator/check_constraint_annotation/annotation_builder.rb
@@ -24,7 +24,13 @@ module AnnotateRb
 
           max_size = check_constraints.map { |check_constraint| check_constraint.name.size }.max + 1
           check_constraints.sort_by(&:name).each do |check_constraint|
-            expression = check_constraint.expression ? "(#{check_constraint.expression.squish})" : nil
+            expression = if check_constraint.expression
+              not_validated = if !check_constraint.validated?
+                "NOT VALID"
+              end
+
+              "(#{check_constraint.expression.squish}) #{not_validated}".squish
+            end
 
             constraint_info += if @options[:format_markdown]
               cc_info_in_markdown(check_constraint.name, expression)

--- a/spec/lib/annotate_rb/model_annotator/annotation_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/annotation_builder_spec.rb
@@ -2016,6 +2016,35 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationBuilder do
         is_expected.to eq expected_result
       end
 
+      context "when constraint is not valid" do
+        let :custom_connection do
+          check_constraints = [
+            mock_check_constraint("must_be_us_adult", "age >= 18", false)
+          ]
+
+          mock_connection([], [], check_constraints)
+        end
+        let :expected_result do
+          <<~EOS
+            # == Schema Information
+            #
+            # Table name: users
+            #
+            #  id  :integer          not null, primary key
+            #  age :integer          not null
+            #
+            # Check Constraints
+            #
+            #  must_be_us_adult  (age >= 18) NOT VALID
+            #
+          EOS
+        end
+
+        it "returns schema info without check constraints" do
+          is_expected.to eq expected_result
+        end
+      end
+
       context "when option is set to false" do
         let(:options) do
           AnnotateRb::Options.new({show_check_constraints: false})

--- a/spec/support/annotate_test_helpers.rb
+++ b/spec/support/annotate_test_helpers.rb
@@ -103,9 +103,10 @@ module AnnotateTestHelpers
     double("Column", stubs)
   end
 
-  def mock_check_constraint(name, expression)
+  def mock_check_constraint(name, expression, validated = true)
     double("CheckConstraintDefinition",
       name: name,
-      expression: expression)
+      expression: expression,
+      validated?: validated)
   end
 end


### PR DESCRIPTION
Thank you for forking annotate_models, cleaning up the code, and providing further maintenance for it 🙏 

We were about to swap our extremely old fork with check constraint support to annotaterb and noticed that `NOT VALID` constraints are not fully annotated.

For example, one of our model annotations would end up missing the `NOT VALID` portion after migrating:
```diff
diff --git a/app/models/model_name.rb b/app/models/model_name.rb
index f39ff14a38..c7220921cb 100644
--- a/app/models/model_name.rb
+++ b/app/models/model_name.rb
@@ -34,10 +34,10 @@
 #
 #  fk_rails_...  (foreign_table_id => foreign_table_name.id)
 #
-# CHECK Constraints
+# Check Constraints
 #
-#  positive_check  ((column_a > 0)) NOT VALID
-#  length_check    ((length(column_b) <= 100000)) NOT VALID
+#  positive_check  (column_a > 0)
+#  length_check    (length(column_b) <= 100000)
 #

 class ModelName < ApplicationRecord
```

So I went ahead and added support for it.

I'm not sure what the oldest Rails version you want to support is, but it seems that `validated?` is [available from Rails 5.2.2 onwards](https://github.com/rails/rails/commit/8203482a9ef9bd60d5014745fd7af868d9954b1d#diff-fac852e063eee718c2af44dec6f80b1b46f52f8aae7936e5eea6b2eab08cf2f7R90-R94).