### PR TITLE
Annotate routes on DB tasks to match the old annotate gem behavior

### DIFF
--- a/lib/annotate_rb/tasks/annotate_models_migrate.rake
+++ b/lib/annotate_rb/tasks/annotate_models_migrate.rake
@@ -30,6 +30,7 @@ migration_tasks.each do |task|
 
     Rake::Task[task_name].enhance do
       ::AnnotateRb::Runner.run(["models"])
+      ::AnnotateRb::Runner.run(["routes"])
     end
   end
 end


### PR DESCRIPTION
Thanks for creating this new annotate gem. I propose to also run `routes` command after `models` command within DB tasks to match the old annotate gem behavior. I think it is easier to run `rails db:migrate` after each change in a model or `routes.rb`, than remembering to run either `rails db:migrate` or `annotaterb routes`.