### PR TITLE
Correct uses of `respond_to` in AnnotationDecider

### DIFF
--- a/lib/annotate_rb/model_annotator/annotation_decider.rb
+++ b/lib/annotate_rb/model_annotator/annotation_decider.rb
@@ -23,8 +23,8 @@ module AnnotateRb
           return false if !klass_is_a_class
 
           klass_inherits_active_record_base = klass < ActiveRecord::Base
-          klass_is_not_abstract = klass.respond_to?(:abstract_class) && !klass.abstract_class?
-          klass_table_exists = klass.respond_to?(:abstract_class) && klass.table_exists?
+          klass_is_not_abstract = klass.respond_to?(:abstract_class?) && !klass.abstract_class?
+          klass_table_exists = klass.respond_to?(:table_exists?) && klass.table_exists?
 
           not_sure_this_conditional = (!@options[:exclude_sti_subclasses] || !(klass.superclass < ActiveRecord::Base && klass.table_name == klass.superclass.table_name))
 


### PR DESCRIPTION
In our project we have more than just Active Record models within our `models` folder. After switching to this gem we noticed a couple errors being raised when attempting to decide if some of those should be annotated or not.

For example, a class that inherits from `Dry::Struct` responds to `abstract_class` but not to `abstract_class?`.

```ruby
> class Demo < Dry::Struct; end
> Demo.abstract_class
=> Dry::Struct
> Demo.abstract_class?
(irb):3:in `<main>': undefined method `abstract_class?' for class Demo (NoMethodError)
```