### PR TITLE
Allow for separating associations into their own section in the annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Additional options that work for annotating models and routes
         --ignore-model-subdirects    Ignore subdirectories of the models directory
         --sort                       Sort columns alphabetically, rather than in creation order
         --classified-sort            Sort columns alphabetically, but first goes id, then the rest columns, then the timestamp columns and then the association columns
+        --separate-associations      Puts associations in their own section
     -R, --require path               Additional file to require before loading models, may be used multiple times
     -e [tests,fixtures,factories,serializers],
         --exclude                    Do not annotate fixtures, test files, factories, and/or serializers

--- a/annotaterb.gemspec
+++ b/annotaterb.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name = "annotaterb"
-  spec.version = File.read("VERSION").strip
+  spec.version = File.read(__dir__ + "/VERSION").strip
   spec.authors = ["Andrew W. Lee"]
   spec.email = ["git@drewlee.com"]
 
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["VERSION", "CHANGELOG.md", "LICENSE.txt", "README.md", "lib/**/*"]
   spec.bindir = "exe"
-  spec.executables = Dir["exe/*"].map { |exe| File.basename(exe) }
+  spec.executables = Dir[__dir__ + "/exe/*"].map { |exe| File.basename(exe) }
   spec.require_paths = ["lib"]
 end

--- a/lib/annotate_rb/model_annotator/annotation.rb
+++ b/lib/annotate_rb/model_annotator/annotation.rb
@@ -5,6 +5,7 @@ module AnnotateRb
     module Annotation
       autoload :AnnotationBuilder, "annotate_rb/model_annotator/annotation/annotation_builder"
       autoload :MainHeader, "annotate_rb/model_annotator/annotation/main_header"
+      autoload :AssociationsHeader, "annotate_rb/model_annotator/annotation/associations_header"
       autoload :SchemaHeader, "annotate_rb/model_annotator/annotation/schema_header"
       autoload :MarkdownHeader, "annotate_rb/model_annotator/annotation/markdown_header"
       autoload :SchemaFooter, "annotate_rb/model_annotator/annotation/schema_footer"

--- a/lib/annotate_rb/model_annotator/annotation/annotation_builder.rb
+++ b/lib/annotate_rb/model_annotator/annotation/annotation_builder.rb
@@ -18,7 +18,7 @@ module AnnotateRb
           end
 
           def body
-            if @options[:separate_associations] and not associations.empty?
+            if @options[:separate_associations] && !associations.empty?
               [
                 MainHeader.new(version, @options[:include_version]),
                 SchemaHeader.new(table_name, table_comment, @options),

--- a/lib/annotate_rb/model_annotator/annotation/annotation_builder.rb
+++ b/lib/annotate_rb/model_annotator/annotation/annotation_builder.rb
@@ -18,16 +18,31 @@ module AnnotateRb
           end
 
           def body
-            [
-              MainHeader.new(version, @options[:include_version]),
-              SchemaHeader.new(table_name, table_comment, @options),
-              MarkdownHeader.new(max_size),
-              *columns,
-              IndexAnnotation::AnnotationBuilder.new(@model, @options).build,
-              ForeignKeyAnnotation::AnnotationBuilder.new(@model, @options).build,
-              CheckConstraintAnnotation::AnnotationBuilder.new(@model, @options).build,
-              SchemaFooter.new
-            ]
+            if @options[:separate_associations] and not associations.empty?
+              [
+                MainHeader.new(version, @options[:include_version]),
+                SchemaHeader.new(table_name, table_comment, @options),
+                MarkdownHeader.new(max_size),
+                *columns,
+                AssociationsHeader.new,
+                *associations,
+                IndexAnnotation::AnnotationBuilder.new(@model, @options).build,
+                ForeignKeyAnnotation::AnnotationBuilder.new(@model, @options).build,
+                CheckConstraintAnnotation::AnnotationBuilder.new(@model, @options).build,
+                SchemaFooter.new
+              ]
+            else
+              [
+                MainHeader.new(version, @options[:include_version]),
+                SchemaHeader.new(table_name, table_comment, @options),
+                MarkdownHeader.new(max_size),
+                *columns,
+                IndexAnnotation::AnnotationBuilder.new(@model, @options).build,
+                ForeignKeyAnnotation::AnnotationBuilder.new(@model, @options).build,
+                CheckConstraintAnnotation::AnnotationBuilder.new(@model, @options).build,
+                SchemaFooter.new
+              ]
+            end
           end
 
           def build
@@ -49,6 +64,12 @@ module AnnotateRb
           def columns
             @model.columns.map do |col|
               _component = ColumnAnnotation::AnnotationBuilder.new(col, @model, max_size, @options).build
+            end
+          end
+
+          def associations
+            @model.associations.map do |assoc|
+              _component = ColumnAnnotation::AnnotationBuilder.new(assoc, @model, max_size, @options).build
             end
           end
         end

--- a/lib/annotate_rb/model_annotator/annotation/associations_header.rb
+++ b/lib/annotate_rb/model_annotator/annotation/associations_header.rb
@@ -4,9 +4,6 @@ module AnnotateRb
   module ModelAnnotator
     module Annotation
       class AssociationsHeader < Components::Base
-        def initialize
-        end
-
         def to_default
           "#\n# Associations\n#"
         end

--- a/lib/annotate_rb/model_annotator/annotation/associations_header.rb
+++ b/lib/annotate_rb/model_annotator/annotation/associations_header.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module AnnotateRb
+  module ModelAnnotator
+    module Annotation
+      class AssociationsHeader < Components::Base
+        def initialize
+        end
+
+        def to_default
+          "#\n# Associations\n#"
+        end
+
+        def to_markdown
+          "#\n# Associations\n#"
+        end
+      end
+    end
+  end
+end

--- a/lib/annotate_rb/model_annotator/foreign_key_annotation/foreign_key_component_builder.rb
+++ b/lib/annotate_rb/model_annotator/foreign_key_annotation/foreign_key_component_builder.rb
@@ -38,7 +38,7 @@ module AnnotateRb
 
         def ref_info
           if foreign_key.column.is_a?(Array) # Composite foreign key using multiple columns
-            "#{stringified_columns} => #{foreign_key.to_table}#{stringified_primary_key}"
+            "#{stringified_columns} => #{foreign_key.to_table}.#{stringified_primary_key}"
           else
             "#{foreign_key.column} => #{foreign_key.to_table}.#{foreign_key.primary_key}"
           end

--- a/lib/annotate_rb/model_annotator/model_wrapper.rb
+++ b/lib/annotate_rb/model_annotator/model_wrapper.rb
@@ -33,7 +33,7 @@ module AnnotateRb
         @columns ||=
           begin
             cols = columns_before_sort
-            cols = cols.reject{ |c| c.name[-3, 3].eql?("_id") } if @options[:separate_associations]
+            cols = cols.reject { |c| c.name[-3, 3].eql?("_id") } if @options[:separate_associations]
 
             cols = cols.sort_by(&:name) if @options[:sort]
             cols = classified_sort(cols) if @options[:classified_sort]
@@ -43,12 +43,12 @@ module AnnotateRb
       end
 
       def associations
-        @associations ||= 
+        @associations ||=
           begin
             cols = columns_before_sort
-            assocs = cols.select{ |c| c.name[-3, 3].eql?("_id") }
+            assocs = cols.select { |c| c.name[-3, 3].eql?("_id") }
 
-            assocs = assocs.sort_by(&:name) if @options[:sort] or @options[:classified_sort]
+            assocs = assocs.sort_by(&:name) if @options[:sort] || @options[:classified_sort]
 
             assocs
           end

--- a/lib/annotate_rb/options.rb
+++ b/lib/annotate_rb/options.rb
@@ -26,6 +26,7 @@ module AnnotateRb
     }.freeze
 
     FLAG_OPTIONS = {
+      separate_associations: false, # ModelAnnotator
       classified_sort: true, # ModelAnnotator
       exclude_controllers: true, # ModelAnnotator
       exclude_factories: false, # ModelAnnotator
@@ -93,6 +94,7 @@ module AnnotateRb
     DEFAULT_OPTIONS = {}.merge(POSITION_OPTIONS, FLAG_OPTIONS, OTHER_OPTIONS, PATH_OPTIONS).freeze
 
     FLAG_OPTION_KEYS = [
+      :separate_associations,
       :classified_sort,
       :exclude_controllers,
       :exclude_factories,

--- a/spec/lib/annotate_rb/model_annotator/annotation/annotation_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/annotation/annotation_builder_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotation::AnnotationBuilder do
           mock_column("name", :string, limit: 50),
           mock_column("user_id", :integer, limit: 8),
           mock_column("notes", :text, limit: 55),
-          mock_column("id", :integer, limit: 8),
+          mock_column("id", :integer, limit: 8)
         ]
       end
 
@@ -202,7 +202,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotation::AnnotationBuilder do
           mock_column("name", :string, limit: 50),
           mock_column("user_id", :integer, limit: 8),
           mock_column("notes", :text, limit: 55),
-          mock_column("id", :integer, limit: 8),
+          mock_column("id", :integer, limit: 8)
         ]
       end
 
@@ -244,7 +244,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotation::AnnotationBuilder do
           mock_column("name", :string, limit: 50),
           mock_column("user_id", :integer, limit: 8),
           mock_column("notes", :text, limit: 55),
-          mock_column("id", :integer, limit: 8),
+          mock_column("id", :integer, limit: 8)
         ]
       end
 

--- a/spec/lib/annotate_rb/model_annotator/annotation/annotation_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/annotation/annotation_builder_spec.rb
@@ -162,7 +162,89 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotation::AnnotationBuilder do
           mock_column("active", :boolean, limit: 1),
           mock_column("name", :string, limit: 50),
           mock_column("user_id", :integer, limit: 8),
-          mock_column("notes", :text, limit: 55)
+          mock_column("notes", :text, limit: 55),
+          mock_column("id", :integer, limit: 8),
+        ]
+      end
+
+      let :expected_result do
+        <<~EOS
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id      :integer          not null, primary key
+          #  active  :boolean          not null
+          #  name    :string(50)       not null
+          #  notes   :text(55)         not null
+          #  user_id :integer          not null
+          #
+        EOS
+      end
+
+      it 'works with option "classified_sort"' do
+        is_expected.to eq expected_result
+      end
+    end
+
+    context 'when "separate_associations" and "classified_sort" are true' do
+      let :primary_key do
+        :id
+      end
+
+      let :options do
+        AnnotateRb::Options.new({classified_sort: true, separate_associations: true})
+      end
+
+      let :columns do
+        [
+          mock_column("active", :boolean, limit: 1),
+          mock_column("name", :string, limit: 50),
+          mock_column("user_id", :integer, limit: 8),
+          mock_column("notes", :text, limit: 55),
+          mock_column("id", :integer, limit: 8),
+        ]
+      end
+
+      let :expected_result do
+        <<~EOS
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id      :integer          not null, primary key
+          #  active  :boolean          not null
+          #  name    :string(50)       not null
+          #  notes   :text(55)         not null
+          #
+          # Associations
+          #
+          #  user_id :integer          not null
+          #
+        EOS
+      end
+
+      it 'works with options "separate_associations" and "classified_sort"' do
+        is_expected.to eq expected_result
+      end
+    end
+
+    context 'when "separate_associations" is true and "classified_sort" is false' do
+      let :primary_key do
+        :id
+      end
+
+      let :options do
+        AnnotateRb::Options.new({classified_sort: false, separate_associations: true})
+      end
+
+      let :columns do
+        [
+          mock_column("active", :boolean, limit: 1),
+          mock_column("name", :string, limit: 50),
+          mock_column("user_id", :integer, limit: 8),
+          mock_column("notes", :text, limit: 55),
+          mock_column("id", :integer, limit: 8),
         ]
       end
 
@@ -175,12 +257,16 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotation::AnnotationBuilder do
           #  active  :boolean          not null
           #  name    :string(50)       not null
           #  notes   :text(55)         not null
+          #  id      :integer          not null, primary key
+          #
+          # Associations
+          #
           #  user_id :integer          not null
           #
         EOS
       end
 
-      it 'works with option "classified_sort"' do
+      it 'works with options "separate_associations" and without "classified_sort"' do
         is_expected.to eq expected_result
       end
     end

--- a/spec/lib/annotate_rb/model_annotator/annotation/annotation_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/annotation/annotation_builder_spec.rb
@@ -161,6 +161,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotation::AnnotationBuilder do
         [
           mock_column("active", :boolean, limit: 1),
           mock_column("name", :string, limit: 50),
+          mock_column("user_id", :integer, limit: 8),
           mock_column("notes", :text, limit: 55)
         ]
       end
@@ -171,9 +172,10 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotation::AnnotationBuilder do
           #
           # Table name: users
           #
-          #  active :boolean          not null
-          #  name   :string(50)       not null
-          #  notes  :text(55)         not null
+          #  active  :boolean          not null
+          #  name    :string(50)       not null
+          #  notes   :text(55)         not null
+          #  user_id :integer          not null
           #
         EOS
       end

--- a/spec/lib/annotate_rb/model_annotator/foreign_key_annotation/annotation_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/foreign_key_annotation/annotation_builder_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::ForeignKeyAnnotation::AnnotationBuild
           #
           # Foreign Keys
           #
-          #  custom_fk_name       ([tenant_id, customer_id] => customers[tenant_id, id])
+          #  custom_fk_name       ([tenant_id, customer_id] => customers.[tenant_id, id])
           #  fk_rails_cf2568e89e  (foreign_thing_id => foreign_things.id)
         OUTPUT
       end
@@ -146,7 +146,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::ForeignKeyAnnotation::AnnotationBuild
             # ### Foreign Keys
             #
             # * `custom_fk_name`:
-            #     * **`[tenant_id, customer_id] => customers[tenant_id, id]`**
+            #     * **`[tenant_id, customer_id] => customers.[tenant_id, id]`**
             # * `fk_rails_cf2568e89e`:
             #     * **`foreign_thing_id => foreign_things.id`**
           OUTPUT


### PR DESCRIPTION
Adds a `--separate-associations` option which puts associations into their own section.  This allows for easier eyeballing of associations in the table, even more so than `--classified-sort`.  Tests and updated README included.

Produces output like :

```
# == Schema Information
#
# Table name: team_users
#
#  id         :bigint           not null, primary key
#  roles      :jsonb            not null
#  created_at :datetime         not null
#  updated_at :datetime         not null
#
# Associations
#
#  team_id    :bigint           not null
#  user_id    :bigint           not null
#
# Indexes
#
#  index_team_users_on_team_id  (team_id)
#  index_team_users_on_user_id  (user_id)
#
# Foreign Keys
#
#  fk_rails_6a8dc6a6fc  (team_id => teams.id)
#  fk_rails_8b0a3daf0d  (user_id => users.id)
#
```

The pull request also includes a change to add a period between the table name and composite keys.  Previously it would produce :

```
#  fk_rails_da54bff5b7  ([team_id, cheese_id] => cheeses[team_id, id])
```

And now :

```
#  fk_rails_da54bff5b7  ([team_id, cheese_id] => cheeses.[team_id, id])
```

which better matches the formatting of non-composite keys.

And lastly, a change to gemspec which allows the Gem to be used locally with `bundle config set local.annotaterb <local-path>` inside a Rails app, which avoids the need to commit and push inside annotaterb, then bundle update in the Rails app, so see how changes affect real-world output.