### PR TITLE
Fix double-loading of Rakefile

### DIFF
--- a/lib/annotate_rb/rake_bootstrapper.rb
+++ b/lib/annotate_rb/rake_bootstrapper.rb
@@ -12,14 +12,6 @@ module AnnotateRb
         rescue
           nil
         end
-
-        unless defined?(Rails)
-          # Not in a Rails project, so time to load up the parts of
-          # ActiveSupport we need.
-          require "active_support"
-          require "active_support/core_ext/class/subclasses"
-          require "active_support/core_ext/string/inflections"
-        end
       end
     end
   end

--- a/lib/annotate_rb/rake_bootstrapper.rb
+++ b/lib/annotate_rb/rake_bootstrapper.rb
@@ -4,14 +4,6 @@ module AnnotateRb
   class RakeBootstrapper
     class << self
       def call(options)
-        begin
-          require "rake/dsl_definition"
-        rescue => e
-          # We might just be on an old version of Rake...
-          warn e.message
-          exit e.status_code
-        end
-
         require "rake"
         load "./Rakefile" if File.exist?("./Rakefile")
 

--- a/lib/annotate_rb/rake_bootstrapper.rb
+++ b/lib/annotate_rb/rake_bootstrapper.rb
@@ -5,7 +5,7 @@ module AnnotateRb
     class << self
       def call(options)
         require "rake"
-        load "./Rakefile" if File.exist?("./Rakefile")
+        load "./Rakefile" if File.exist?("./Rakefile") && !Rake::Task.task_defined?(:environment)
 
         begin
           Rake::Task[:environment].invoke


### PR DESCRIPTION
See #130 for problem discussion.

This also drops a lot of legacy and/or unnecessary code from `AnnotateRb::RakeBootstrapper`.