### PR TITLE
Add Ruby 3.3 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.2']
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3']
 
     steps:
       - name: Checkout
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         adapter: [ 'mysql2', 'pg', 'sqlite3' ]
-        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2', '3.3' ]
 
     steps:
       - name: Checkout

--- a/spec/integration/rails_generator_install_spec.rb
+++ b/spec/integration/rails_generator_install_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Generator installs rake file", type: "aruba" do
       expect(exist?(rake_task_file)).to be_truthy
 
       # TODO: Improve this so we don't have to rely on `exit_timeout`
-      _cmd = run_command(generator_install_command, exit_timeout: 3)
+      _cmd = run_command(generator_install_command, exit_timeout: 5)
       # Because the rake task file already exists, there will be a conflict in the Rails generator.
       # The prompt should look something like this:
       #


### PR DESCRIPTION
This PR adds Ruby 3.3 to CI. It also changes the timeout for an integration test case because it seemed to fail on Ruby 3.3, presumably due to Ruby 3.3 running slower.