### PR TITLE
Include the length of comments in max_schema_info_width only when the with_comment and with_column_comments option is true.

### DIFF
--- a/lib/annotate_rb/model_annotator/model_wrapper.rb
+++ b/lib/annotate_rb/model_annotator/model_wrapper.rb
@@ -128,7 +128,12 @@ module AnnotateRb
       end
 
       def with_comments?
-        @with_comments ||= raw_columns.first.respond_to?(:comment) &&
+        return @with_comments if instance_variable_defined?(:@with_comments)
+
+        @with_comments =
+          @options[:with_comment] &&
+          @options[:with_column_comments] &&
+          raw_columns.first.respond_to?(:comment) &&
           raw_columns.map(&:comment).any? { |comment| !comment.nil? }
       end
 

--- a/spec/lib/annotate_rb/model_annotator/model_wrapper_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/model_wrapper_spec.rb
@@ -26,4 +26,77 @@ RSpec.describe AnnotateRb::ModelAnnotator::ModelWrapper do
       end
     end
   end
+
+  describe "#max_schema_info_width" do
+    subject { described_class.new(*args).max_schema_info_width }
+
+    let(:args) { [klass, options] }
+    let(:klass) do
+      mock_class(:users,
+        :id,
+        [
+          id_column,
+          name_column
+        ])
+    end
+    let(:id_column) { mock_column("id", :integer, comment: "") }
+    let(:name_column) { mock_column("name", :string, comment: "[is commented]") }
+
+    context "with options[:with_comment] and options[:with_column_comments] are true" do
+      let(:options) do
+        AnnotateRb::Options.new({
+          with_comment: true,
+          with_column_comments: true,
+          format_rdoc: format_rdoc_option
+        })
+      end
+      let(:with_comments_lentgh) { 2 }
+      let(:rdoc_length) { options[:format_rdoc] ? 5 : 1 }
+      let(:expect_length) { name_column.name.length + name_column.comment.length + with_comments_lentgh + rdoc_length }
+
+      context "with options[:format_rdoc]" do
+        let!(:format_rdoc_option) { true }
+
+        it "should return the max width ncluding the length of the comments and the length of the rdoc" do
+          is_expected.to eq(expect_length)
+        end
+      end
+
+      context "with options[:format_rdoc] is false" do
+        let!(:format_rdoc_option) { false }
+
+        it "should return the max width ncluding the length of the comments" do
+          is_expected.to eq(expect_length)
+        end
+      end
+    end
+
+    context "with options[:with_column_comments] is false" do
+      let(:options) do
+        AnnotateRb::Options.new({
+          with_comment: true,
+          with_column_comments: false,
+          format_rdoc: format_rdoc_option
+        })
+      end
+      let(:rdoc_length) { options[:format_rdoc] ? 5 : 1 }
+      let(:expect_length) { name_column.name.length + rdoc_length }
+
+      context "with options[:format_rdoc]" do
+        let!(:format_rdoc_option) { true }
+
+        it "should return the max width ncluding the length of the rdoc" do
+          is_expected.to eq(expect_length)
+        end
+      end
+
+      context "with options[:format_rdoc] is false" do
+        let!(:format_rdoc_option) { false }
+
+        it "should return the max width" do
+          is_expected.to eq(expect_length)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description

close: #144 

By including the length of comments in max_schema_info_width only when both the with_comment and with_column_comments options are true, we can avoid creating unnecessary space between the column and data type.

