### PR TITLE
Support postgres NULLS NOT DISTINCT clause in unique index

### DIFF
--- a/lib/annotate_rb/model_annotator/index_annotation/index_component.rb
+++ b/lib/annotate_rb/model_annotator/index_annotation/index_component.rb
@@ -14,6 +14,12 @@ module AnnotateRb
         def to_default
           unique_info = index.unique ? " UNIQUE" : ""
 
+          nulls_not_distinct_info = if index.try(:nulls_not_distinct)
+            " NULLS NOT DISTINCT"
+          else
+            ""
+          end
+
           value = index.try(:where).try(:to_s)
           where_info = if value.present?
             " WHERE #{value}"
@@ -30,10 +36,11 @@ module AnnotateRb
 
           # standard:disable Lint/FormatParameterMismatch
           sprintf(
-            "#  %-#{max_size}.#{max_size}s %s%s%s%s",
+            "#  %-#{max_size}.#{max_size}s %s%s%s%s%s",
             index.name,
             "(#{columns_info.join(",")})",
             unique_info,
+            nulls_not_distinct_info,
             where_info,
             using_info
           ).rstrip
@@ -42,6 +49,12 @@ module AnnotateRb
 
         def to_markdown
           unique_info = index.unique ? " _unique_" : ""
+
+          nulls_not_distinct_info = if index.try(:nulls_not_distinct)
+            " _nulls_not_distinct_"
+          else
+            ""
+          end
 
           value = index.try(:where).try(:to_s)
           where_info = if value.present?
@@ -58,8 +71,9 @@ module AnnotateRb
           end
 
           details = sprintf(
-            "%s%s%s",
+            "%s%s%s%s",
             unique_info,
+            nulls_not_distinct_info,
             where_info,
             using_info
           ).strip

--- a/spec/lib/annotate_rb/model_annotator/annotation/annotation_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/annotation/annotation_builder_spec.rb
@@ -422,6 +422,45 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotation::AnnotationBuilder do
           end
         end
 
+        context 'when one of indexes includes "unique" clause with "not null distinct"' do
+          let :indexes do
+            [
+              mock_index("index_rails_02e851e3b7", columns: ["id"]),
+              mock_index("index_rails_02e851e3b8",
+                columns: ["foreign_thing_id"],
+                unique: true,
+                nulls_not_distinct: true)
+            ]
+          end
+
+          let :expected_result do
+            <<~EOS
+              # ## Schema Information
+              #
+              # Table name: `users`
+              #
+              # ### Columns
+              #
+              # Name        | Type               | Attributes
+              # ----------- | ------------------ | ---------------------------
+              # **`id`**    | `integer`          | `not null, primary key`
+              # **`name`**  | `string(50)`       | `not null`
+              #
+              # ### Indexes
+              #
+              # * `index_rails_02e851e3b7`:
+              #     * **`id`**
+              # * `index_rails_02e851e3b8` (_unique_ _nulls_not_distinct_):
+              #     * **`foreign_thing_id`**
+              #
+            EOS
+          end
+
+          it "returns schema info with index information in Markdown format" do
+            is_expected.to eq expected_result
+          end
+        end
+
         context "when one of indexes includes ordered index key" do
           let :indexes do
             [

--- a/spec/lib/annotate_rb/model_annotator/index_annotation/annotation_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/index_annotation/annotation_builder_spec.rb
@@ -137,5 +137,31 @@ RSpec.describe AnnotateRb::ModelAnnotator::IndexAnnotation::AnnotationBuilder do
         expect(default_format).to eq(expected_result)
       end
     end
+
+    context "index includes a unique nulls not distinct clause" do
+      let(:indexes) do
+        [
+          mock_index("index_rails_02e851e3b7", columns: ["id"]),
+          mock_index("index_rails_02e851e3b8",
+            columns: %w[firstname surname],
+            unique: true,
+            nulls_not_distinct: true)
+        ]
+      end
+
+      let(:expected_result) do
+        <<~EOS.strip
+          #
+          # Indexes
+          #
+          #  index_rails_02e851e3b7  (id)
+          #  index_rails_02e851e3b8  (firstname,surname) UNIQUE NULLS NOT DISTINCT
+        EOS
+      end
+
+      it "matches the expected result" do
+        expect(default_format).to eq(expected_result)
+      end
+    end
   end
 end

--- a/spec/support/annotate_test_helpers.rb
+++ b/spec/support/annotate_test_helpers.rb
@@ -21,6 +21,7 @@ module AnnotateTestHelpers
       name: name,
       columns: params[:columns] || [],
       unique: params[:unique] || false,
+      nulls_not_distinct: params[:nulls_not_distinct] || false,
       orders: params[:orders] || {},
       where: params[:where],
       using: params[:using])


### PR DESCRIPTION
Postgres supports NULLS NOT DISTINCT for unique indexes https://www.postgresql.org/docs/current/indexes-unique.html#INDEXES-UNIQUE

This causes the index to treat nulls as equal which is important information to surface when one of the columns is nullable. 

This utilizes `nulls_not_distinct` in the [index definition](https://apidock.com/rails/ActiveRecord/ConnectionAdapters/IndexDefinition/new/class) to surface this information 