### PR TITLE
Fix updating of indexes containing escaped characters

### DIFF
--- a/lib/annotate_rb/model_annotator/annotated_file/updater.rb
+++ b/lib/annotate_rb/model_annotator/annotated_file/updater.rb
@@ -20,7 +20,7 @@ module AnnotateRb
 
           new_annotation = wrapped_content(@new_annotations)
 
-          _content = @file_content.sub(@parsed_file.annotations, new_annotation)
+          _content = @file_content.sub(@parsed_file.annotations) { new_annotation }
         end
 
         private


### PR DESCRIPTION
There are a number of different mechanisms with [String#sub](https://ruby-doc.org/core-2.4.5/String.html#method-i-sub) that pertain to the matching of backreferences and capture groups when using either the String or Hash type args for the replacement arg.

>If replacement is a String that looks like a pattern's capture group but is actually not a pattern capture group e.g. "\'", then it will have to be preceded by two backslashes like so "\\'".

When an index contains unescaped characters, those are being incorrectly interpreted as capture groups. Using the block version of #sub avoids this.

For example, here's the behaviour we see with an index containing special characters that need escaping.

Existing index:
```
# Indexes
# 
# index_xyz   (regexp_replace((some_column)::text, '[[:space:]]|\+61|^[0]'::text, ''::text, 'g'::text))
```

Updated index:
```
# Indexes
# 
# index_xyz   (regexp_replace((some_column)::text, '[[:space:]]|61|^[0]'::text, ''::text, 'g'::text))
```

This becomes a problem given that the issue is in the `Updater` itself; we get stuck in a loop where annotation changes are always being detected, so a CI step with `--frozen` will always fail.