### PR TITLE
Support parsing of dynamic fixture erb yml files

### DIFF
--- a/lib/annotate_rb/model_annotator/file_parser/yml_parser.rb
+++ b/lib/annotate_rb/model_annotator/file_parser/yml_parser.rb
@@ -40,7 +40,14 @@ module AnnotateRb
         def parse_yml
           # https://docs.ruby-lang.org/en/master/Psych.html#module-Psych-label-Reading+to+Psych-3A-3ANodes-3A-3AStream+structure
           parser = Psych.parser
-          parser.parse(@input)
+          begin
+            parser.parse(@input)
+          rescue Psych::SyntaxError => _e
+            # "Dynamic fixtures with ERB" exist in Rails, and will cause Psych.parser to error
+            # This is a hacky solution to get around this and still have it parse
+            erb_yml = ERB.new(@input).result
+            parser.parse(erb_yml)
+          end
 
           stream = parser.handler.root
 

--- a/spec/lib/annotate_rb/model_annotator/file_parser/yml_parser_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/file_parser/yml_parser_spec.rb
@@ -109,6 +109,32 @@ RSpec.describe AnnotateRb::ModelAnnotator::FileParser::YmlParser do
     end
   end
 
+  context "with a yml file that has erb" do
+    let(:input) do
+      <<~FILE
+        # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+        <% 1.upto(100) do |i| %>
+        user_<%= i %>:
+          name: User <%= i %>
+          email: user_<%= i %>@example.com
+        <% end %>
+
+      FILE
+    end
+    let(:expected_comments) do
+      [
+        ["# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html", 0]
+      ]
+    end
+    let(:expected_starts) { [[nil, 3]] }
+    let(:expected_ends) { [[nil, 404]] }
+
+    it "parses without errors" do
+      check_it_parses_correctly
+    end
+  end
+
   context "with an empty yml file" do
     let(:input) do
       <<~FILE

--- a/spec/lib/annotate_rb/model_annotator/file_parser/yml_parser_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/file_parser/yml_parser_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::FileParser::YmlParser do
     end
   end
 
-  context "with a yml file that only has comments", focus: true do
+  context "with a yml file that only has comments" do
     let(:input) do
       <<~FILE
         #

--- a/spec/lib/annotate_rb/model_annotator/single_file_annotator_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/single_file_annotator_spec.rb
@@ -314,5 +314,122 @@ RSpec.describe AnnotateRb::ModelAnnotator::SingleFileAnnotator do
         expect(File.read(@model_file_name)).to eq(expected_file_content)
       end
     end
+
+    describe "annotating a yml file with erb with position before" do
+      let(:options) { AnnotateRb::Options.new({with_comment: true, position_in_fixture: "before"}) }
+      let(:schema_info) do
+        <<~SCHEMA
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id                          :integer          not null, primary key
+          #  name([sensitivity: medium]) :string(50)       not null
+          #  email                       :string
+          #
+        SCHEMA
+      end
+      let(:starting_file_content) do
+        <<~FILE
+          # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+          <% 1.upto(100) do |i| %>
+          user_<%= i %>:
+            name: User <%= i %>
+            email: user_<%= i %>@example.com
+          <% end %>
+
+        FILE
+      end
+      let(:expected_file_content) do
+        <<~FILE
+          # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+          <% 1.upto(100) do |i| %>
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id                          :integer          not null, primary key
+          #  name([sensitivity: medium]) :string(50)       not null
+          #  email                       :string
+          #
+          user_<%= i %>:
+            name: User <%= i %>
+            email: user_<%= i %>@example.com
+          <% end %>
+
+        FILE
+      end
+
+      before do
+        @model_dir = Dir.mktmpdir("annotaterb")
+        (@model_file_name, _file_content) = write_model("user.yml", starting_file_content)
+      end
+
+      it "updates the annotations" do
+        described_class.call(@model_file_name, schema_info, :position_in_fixture, options)
+        expect(File.read(@model_file_name)).to eq(expected_file_content)
+      end
+    end
+
+    describe "annotating a yml file with erb with position after" do
+      let(:options) { AnnotateRb::Options.new({with_comment: true, position_in_fixture: "after"}) }
+      let(:schema_info) do
+        <<~SCHEMA
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id                          :integer          not null, primary key
+          #  name([sensitivity: medium]) :string(50)       not null
+          #  email                       :string
+          #
+        SCHEMA
+      end
+      let(:starting_file_content) do
+        <<~FILE
+          # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+          <% 1.upto(100) do |i| %>
+          user_<%= i %>:
+            name: User <%= i %>
+            email: user_<%= i %>@example.com
+          <% end %>
+
+        FILE
+      end
+      let(:expected_file_content) do
+        <<~FILE
+          # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+          <% 1.upto(100) do |i| %>
+          user_<%= i %>:
+            name: User <%= i %>
+            email: user_<%= i %>@example.com
+          <% end %>
+
+
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id                          :integer          not null, primary key
+          #  name([sensitivity: medium]) :string(50)       not null
+          #  email                       :string
+          #
+        FILE
+      end
+
+      before do
+        @model_dir = Dir.mktmpdir("annotaterb")
+        (@model_file_name, _file_content) = write_model("user.yml", starting_file_content)
+      end
+
+      it "updates the annotations" do
+        described_class.call(@model_file_name, schema_info, :position_in_fixture, options)
+        expect(File.read(@model_file_name)).to eq(expected_file_content)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds support for dynamic fixtures, which are yml files with Ruby code in them. Rails supports this so we also want to support this.

Before this change, Ruby's yml parser, Psych, would raise `Psych::SyntaxError` when attempting to parse non-valid yml. This change attempts to parse yml normally, but if it fails will run the input through the Erb evaluator and then attempt to parse the output using Psych.

Addresses #149 