### PR TITLE
Opt-in for MFA requirement

### DIFF
--- a/annotaterb.gemspec
+++ b/annotaterb.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://github.com/drwl/annotaterb"
   spec.metadata["changelog_uri"] = "https://github.com/drwl/annotaterb/blob/master/CHANGELOG.md"
   spec.metadata["bug_tracker_uri"] = "https://github.com/drwl/annotaterb/issues"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.files = Dir["VERSION", "CHANGELOG.md", "LICENSE.txt", "README.md", "lib/**/*"]
   spec.bindir = "exe"


### PR DESCRIPTION
Make the gem more secure by requiring that all privileged operations by any of the owners require OTP.

Ref: https://guides.rubygems.org/mfa-requirement-opt-in/