### PR TITLE
Updated COLUMN_PATTERN to handle optional metadata (e.g., constraints or descriptions) enclosed in parentheses.

### DIFF
--- a/lib/annotate_rb/model_annotator/annotation_diff_generator.rb
+++ b/lib/annotate_rb/model_annotator/annotation_diff_generator.rb
@@ -5,7 +5,13 @@ module AnnotateRb
     # Compares the current file content and new annotation block and generates the column annotation differences
     class AnnotationDiffGenerator
       HEADER_PATTERN = /(^# Table name:.*?\n(#.*\r?\n)*\r?)/
-      COLUMN_PATTERN = /^#[\t ]+[\w*.`\[\]():]+[\t ]+.+$/
+      # Example matches:
+      #   - "#  id              :uuid             not null, primary key"
+      #   - "#  title(length 255) :string          not null"
+      #   - "#  status(a/b/c)    :string           not null"
+      #   - "#  created_at       :datetime         not null"
+      #   - "#  updated_at       :datetime         not null"
+      COLUMN_PATTERN = /^#[\t ]+[\w*.`\[\]():]+(?:\(.*?\))?[\t ]+.+$/
 
       class << self
         def call(file_content, annotation_block)

--- a/spec/lib/annotate_rb/model_annotator/annotation_diff_generator_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/annotation_diff_generator_spec.rb
@@ -142,5 +142,55 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationDiffGenerator do
         expect(subject.changed?).to eq(true)
       end
     end
+
+    context "when a new column with metadata in parentheses is added" do
+      let(:annotation_block) do
+        <<~SCHEMA
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id                               :bigint           not null, primary key
+          #  name([sensitivity: medium])      :string(50)       not null
+          #  status(active/pending/inactive)  :string           not null
+          #
+        SCHEMA
+      end
+      let(:file_content) do
+        <<~FILE
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id                               :bigint           not null, primary key
+          #  name([sensitivity: medium])      :string(50)       not null
+          #
+          class User < ApplicationRecord
+          end
+        FILE
+      end
+
+      let(:current_columns) do
+        [
+          "#  id                               :bigint           not null, primary key",
+          "#  name([sensitivity: medium])      :string(50)       not null",
+          "# Table name: users"
+        ]
+      end
+      let(:new_columns) do
+        [
+          "#  id                               :bigint           not null, primary key",
+          "#  name([sensitivity: medium])      :string(50)       not null",
+          "#  status(active/pending/inactive)  :string           not null",
+          "# Table name: users"
+        ]
+      end
+
+      it "returns an AnnotationDiff object with the expected old and new columns" do
+        test_columns_match_expected
+
+        expect(subject.changed?).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
Before: Try fail Regex Link https://rubular.com/r/fMCSHSUICtyUIN
After: Try pass Regex LInk https://rubular.com/r/nwANf5UyNf7OhB

## ISSUE
close https://github.com/drwl/annotaterb/issues/169

## Summary
AnnotateRb was not working when column comments included characters like / or non-English characters such as Japanese.

This PR resolves the issue by extending the regular expression to support a wider range of characters in the metadata inside parentheses.

## Before

```ruby
COLUMN_PATTERN = /^#[\t ]+[\w*.`\[\]():]+(?:\(.*?\))?[\t ]+.+$/
```
With this regular expression, the test cases added in this pull request fail.

```ruby
❯ be rspec spec/lib/annotate_rb/model_annotator/annotation_diff_generator_spec.rb:146
Run options: include {:locations=>{"./spec/lib/annotate_rb/model_annotator/annotation_diff_generator_spec.rb"=>[146]}}

Randomized with seed 43894

AnnotateRb::ModelAnnotator::AnnotationDiffGenerator
  .call
    when a new column with metadata in parentheses is added
      returns an AnnotationDiff object with the expected old and new columns (FAILED - 1)

Failures:

  1) AnnotateRb::ModelAnnotator::AnnotationDiffGenerator.call when a new column with metadata in parentheses is added returns an AnnotationDiff object with the expected old and new columns
     Failure/Error: expect(resulting_new_columns_data).to eq(expected_new_columns_data)
     
       expected: ["#id:bigintnotnull,primarykey", "#name([sensitivity:medium]):string(50)notnull", "#status(active/pending/inactive):stringnotnull", "#Tablename:users"]
            got: ["#id:bigintnotnull,primarykey", "#name([sensitivity:medium]):string(50)notnull", "#Tablename:users"]
     
       (compared using ==)
     # ./spec/lib/annotate_rb/model_annotator/annotation_diff_generator_spec.rb:13:in `test_columns_match_expected'
     # ./spec/lib/annotate_rb/model_annotator/annotation_diff_generator_spec.rb:190:in `block (4 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.3.0/gems/aruba-2.1.0/lib/aruba/rspec.rb:38:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.3.0/gems/aruba-2.1.0/lib/aruba/rspec.rb:25:in `block (2 levels) in <top (required)>'

Finished in 0.00954 seconds (files took 0.38138 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/lib/annotate_rb/model_annotator/annotation_diff_generator_spec.rb:189 # AnnotateRb::ModelAnnotator::AnnotationDiffGenerator.call when a new column with metadata in parentheses is added returns an AnnotationDiff object with the expected old and new columns

Randomized with seed 43894
```


## After

```ruby
COLUMN_PATTERN = /^#[\t ]+[\w*.`\[\]():]+(?:\(.*?\))?[\t ]+.+$/
```

With this updated regular expression, the test cases added in this pull request pass.


```ruby
❯ be rspec spec/lib/annotate_rb/model_annotator/annotation_diff_generator_spec.rb:146
Run options: include {:locations=>{"./spec/lib/annotate_rb/model_annotator/annotation_diff_generator_spec.rb"=>[146]}}

Randomized with seed 57719

AnnotateRb::ModelAnnotator::AnnotationDiffGenerator
  .call
    when a new column with metadata in parentheses is added
      returns an AnnotationDiff object with the expected old and new columns

Finished in 0.00285 seconds (files took 0.65977 seconds to load)
1 example, 0 failures

Randomized with seed 57719
```
