### PR TITLE
chore: ensure Options are initialised with defaults

### DIFF
--- a/spec/lib/annotate_rb/options_spec.rb
+++ b/spec/lib/annotate_rb/options_spec.rb
@@ -51,12 +51,6 @@ RSpec.describe AnnotateRb::Options do
 
       it { expect(subject[:exclude_tests]).to eq(false) }
     end
-  end
-
-  describe ".load_defaults" do
-    subject { described_class.new(options, state).load_defaults }
-
-    let(:state) { {} }
 
     context 'when default value of "show_complete_foreign_keys" is not set' do
       let(:key) { :show_complete_foreign_keys }


### PR DESCRIPTION
I can't see a reason not to load defaults when initialising an Options object (and the comment on line 158/96 suggests it's desired behaviour), so this calls `load_defaults` during init and makes it a private method.

Correct me if I'm wrong, but I also can't see a reason to keep the unused `format_bare` flag option given that arbitrary keys are allowed.

Removes the `*_OPTIONS_KEYS` constants for being redundant.

Tidies up a couple of lines to be clearer.