### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Or install it into your Rails project through the Gemfile:
 group :development do
   ...
 
-  gem "annotaterb"
+  gem "annotaterb", require: "annotate_rb"
   
   ...
 ```


### PR DESCRIPTION
When specifically requiring the gem, the path in `lib` is `annotate_rb.rb`, with the underscore.