### PR TITLE
Chore: alert when multiple conmmands were selected

### DIFF
--- a/lib/annotate_rb/parser.rb
+++ b/lib/annotate_rb/parser.rb
@@ -78,10 +78,11 @@ module AnnotateRb
         version: Commands::PrintVersion.new
       }
 
+      if @commands.size > 1
+        warn "Only one command can be run at a time"
+      end
+
       @options[:command] = if @commands.any?
-        map[@commands.first]
-      elsif @commands.size > 1
-        # TODO: Should raise or alert user that multiple commands were selected but only 1 command will be ran
         map[@commands.first]
       else # None
         map[:help]

--- a/spec/lib/annotate_rb/parser_spec.rb
+++ b/spec/lib/annotate_rb/parser_spec.rb
@@ -35,6 +35,16 @@ module AnnotateRb # rubocop:disable Metrics/ModuleLength
           expect(result).to include(command: instance_of(Commands::PrintVersion))
         end
       end
+
+      context "when given multiple commands" do
+        let(:model_command_option) { "models" }
+        let(:version_command_option) { "--version" }
+        let(:args) { [model_command_option, version_command_option] }
+
+        it "displays a warning to stderr" do
+          expect { result }.to output("Only one command can be run at a time\n").to_stderr
+        end
+      end
     end
 
     context "when given empty args" do


### PR DESCRIPTION
Thank you for developing such a awesome gem. 👍 

In this PR, I have worked on the TODO comment at the following location:
https://github.com/drwl/annotaterb/blob/7746f54b31674603b671db2433cd3d2e3da78fb7/lib/annotate_rb/parser.rb#L84

## Description
I have added an alert message indicating that only one command will be executed when multiple commands are specified.

Additionally, the following section did not enter the conditional branch, so I moved it above `if @commands.any?`.
If you have any better approaches, I would appreciate your suggestions. 
