### PR TITLE
Lock `concurrent-ruby` gem to fix CI

### DIFF
--- a/spec/dummyapp/Gemfile
+++ b/spec/dummyapp/Gemfile
@@ -2,7 +2,12 @@ source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
-gem "rails", "~> 7.0.7", ">= 7.0.7.2"
+gem "rails", "~> 7.0.8"
+
+# Lock the concurrent-ruby gem to version 1.3.4 to ensure compatibility with
+# the current specs. Reference: rails/rails#54260
+# TODO: Remove the line below when upgrading to Rails 7.1 or higher.
+gem "concurrent-ruby", "1.3.4"
 
 case ENV['DATABASE_ADAPTER'] # This feels so wrong
 when 'mysql2'


### PR DESCRIPTION
To address compatibility issues with Rails 7.0, this commit locks `concurrent-ruby` gem to version 1.3.4.

This change is necessary to prevent an uninitialized constant error related to `ActiveSupport::LoggerThreadSafeLevel::Logger`, as documented in issue rails/rails#54260.

By specifying this version, we ensure that our CI integration specs pass consistently, providing a stable development and testing environment.

This measure will remain in place until the integration tests upgrade to Rails 7.1, which involves significant changes that require careful consideration and testing.