### PR TITLE
Fix translation foreign key exclusion bug

### DIFF
--- a/lib/annotate_rb/model_annotator/model_wrapper.rb
+++ b/lib/annotate_rb/model_annotator/model_wrapper.rb
@@ -167,7 +167,7 @@ module AnnotateRb
           :created_at,
           :updated_at,
           :locale,
-          @klass.name.foreign_key.to_sym,
+          @klass.name.foreign_key.to_sym
         ]
       end
     end

--- a/lib/annotate_rb/model_annotator/model_wrapper.rb
+++ b/lib/annotate_rb/model_annotator/model_wrapper.rb
@@ -162,21 +162,12 @@ module AnnotateRb
       # These are the columns that the globalize gem needs to work but
       # are not necessary for the models to be displayed as annotations.
       def ignored_translation_table_columns
-        # Construct the foreign column name in the translations table
-        # eg. Model: Car, foreign column name: car_id
-        foreign_column_name = [
-          @klass.translation_class.to_s
-            .gsub("::Translation", "").gsub("::", "_")
-            .downcase,
-          "_id"
-        ].join.to_sym
-
         [
           :id,
           :created_at,
           :updated_at,
           :locale,
-          foreign_column_name
+          @klass.name.foreign_key.to_sym,
         ]
       end
     end

--- a/spec/dummyapp/.rbenv-gemsets
+++ b/spec/dummyapp/.rbenv-gemsets
@@ -1,0 +1,1 @@
+dummyapp

--- a/spec/lib/annotate_rb/model_annotator/annotation/annotation_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/annotation/annotation_builder_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotation::AnnotationBuilder do
       let :klass do
         mock_class(:posts, primary_key, columns, indexes, foreign_keys).tap do |mock_klass|
           allow(mock_klass).to receive(:translation_class).and_return(translation_klass)
-          allow(mock_klass).to receive(:name).and_return(double("name", foreign_key: double('foreign_key', to_sym: :post_id)))
+          allow(mock_klass).to receive(:name).and_return(double("name", foreign_key: double("foreign_key", to_sym: :post_id)))
         end
       end
 

--- a/spec/lib/annotate_rb/model_annotator/annotation/annotation_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/annotation/annotation_builder_spec.rb
@@ -120,6 +120,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotation::AnnotationBuilder do
       let :klass do
         mock_class(:posts, primary_key, columns, indexes, foreign_keys).tap do |mock_klass|
           allow(mock_klass).to receive(:translation_class).and_return(translation_klass)
+          allow(mock_klass).to receive(:name).and_return(double("name", foreign_key: double('foreign_key', to_sym: :post_id)))
         end
       end
 


### PR DESCRIPTION
I ran into a bug with this logic when using annotaterb + globalize:

For compound names for models such as "ABCustomer", it resulted in "abcustomer_id" being added to the exclusion list, where the actual foreign key name was "ab_customer_id". 

Therefore it was not excluded. And therefore all the annotations for ABCustomer ended up including "ab_customer_id" even though that wasn't an actual column.

This PR includes changes to the unit tests to not break them. However it didn't seem like this bug something I could actually reproduce with the unit tests. I couldn't get the integration test suite working and couldn't spend more time on it right now. 