### PR TITLE
Add expected file to automatically require

### DIFF
--- a/lib/annotaterb.rb
+++ b/lib/annotaterb.rb
@@ -1,0 +1,4 @@
+# Gem names that follow naming convention work seamlessly. However, this gem is "annotaterb" where in code it is
+# AnnotateRb. Because of this, we need this file so that the rest of the library automatically gets required.
+
+require "annotate_rb"


### PR DESCRIPTION
Due to Bundler's naming conventions, `annotaterb` gem does not get automatically required. Per https://github.com/drwl/annotaterb/pull/177, it's expected to have a corresponding `lib/annotaterb.rb` file, but it does not.

This fixes it so that it automatically gets required.