### PR TITLE
Fix `changelog_uri` in gemspec

### DIFF
--- a/annotaterb.gemspec
+++ b/annotaterb.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/drwl/annotaterb"
-  spec.metadata["changelog_uri"] = "https://github.com/drwl/annotaterb/blob/master/CHANGELOG.md"
+  spec.metadata["changelog_uri"] = "https://github.com/drwl/annotaterb/blob/main/CHANGELOG.md"
   spec.metadata["bug_tracker_uri"] = "https://github.com/drwl/annotaterb/issues"
   spec.metadata["rubygems_mfa_required"] = "true"
 


### PR DESCRIPTION
This repository uses `main` for the default branch. This can reduce a redirect when accessing the URI.