### PR TITLE
fix: Handle case when table_name_prefix specified as symbol

### DIFF
--- a/lib/annotate_rb/model_annotator/model_wrapper.rb
+++ b/lib/annotate_rb/model_annotator/model_wrapper.rb
@@ -116,7 +116,7 @@ module AnnotateRb
         return indexes if indexes.any? || !@klass.table_name_prefix
 
         # Try to search the table without prefix
-        table_name_without_prefix = table_name.to_s.sub(@klass.table_name_prefix, "")
+        table_name_without_prefix = table_name.to_s.sub(@klass.table_name_prefix.to_s, "")
         begin
           @klass.connection.indexes(table_name_without_prefix)
         rescue ActiveRecord::StatementInvalid => _e


### PR DESCRIPTION
During of annotation of indexes I have received exception (`'String#sub': wrong argument type Symbol (expected Regexp) (TypeError)`) when some of my AR models use `table_name_prefix` option with Symbol value. In this PR I fixed it and added some specs to cover it by tests