### PR TITLE
Support custom configuration file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Additional options that work for annotating models and routes
         --exclude                    Do not annotate fixtures, test files, factories, and/or serializers
     -f [bare|rdoc|yard|markdown],    Render Schema Information as plain/RDoc/Yard/Markdown
         --format
+    -c, --config_path [path]         Path to configuration file (by default, .annotaterb.yml in the root of the project)
     -p [before|top|after|bottom],    Place the annotations at the top (before) or the bottom (after) of the model/test/fixture/factory/route/serializer file(s)
         --position
         --pc, --position-in-class [before|top|after|bottom]

--- a/lib/annotate_rb/config_finder.rb
+++ b/lib/annotate_rb/config_finder.rb
@@ -5,6 +5,8 @@ module AnnotateRb
     DOTFILE = ".annotaterb.yml"
 
     class << self
+      attr_accessor :config_path
+
       def find_project_root
         # We should expect this method to be called from a Rails project root and returning it
         # e.g. "/Users/drwl/personal/annotaterb/dummyapp"
@@ -12,9 +14,11 @@ module AnnotateRb
       end
 
       def find_project_dotfile
+        return @config_path if @config_path && File.exist?(@config_path)
+
         file_path = File.expand_path(DOTFILE, find_project_root)
 
-        return file_path if File.exist?(file_path)
+        file_path if File.exist?(file_path)
       end
     end
   end

--- a/lib/annotate_rb/parser.rb
+++ b/lib/annotate_rb/parser.rb
@@ -421,6 +421,12 @@ module AnnotateRb
         "Render Schema Information as plain/RDoc/Yard/Markdown") do |format_type|
         @options["format_#{format_type}".to_sym] = true
       end
+
+      option_parser.on("-c",
+        "--config_path [path]",
+        "Path to configuration file (by default, .annotaterb.yml in the root of the project)") do |path|
+        @options[:config_path] = path
+      end
     end
   end
 end

--- a/lib/annotate_rb/runner.rb
+++ b/lib/annotate_rb/runner.rb
@@ -9,23 +9,23 @@ module AnnotateRb
     end
 
     def run(args)
-      config_file_options = ConfigLoader.load_config
       parser = Parser.new(args, {})
 
       parsed_options = parser.parse
       remaining_args = parser.remaining_args
 
+      AnnotateRb::ConfigFinder.config_path = parsed_options[:config_path] if parsed_options[:config_path]
+      config_file_options = ConfigLoader.load_config
       options = config_file_options.merge(parsed_options)
 
-      @options = Options.from(options, {working_args: remaining_args})
+      @options = Options.from(options, { working_args: remaining_args })
       AnnotateRb::RakeBootstrapper.call(@options)
 
-      if @options[:command]
-        @options[:command].call(@options)
-      else
-        # TODO
-        raise "Didn't specify a command"
-      end
+      raise "Didn't specify a command" unless @options[:command]
+
+      @options[:command].call(@options)
+
+      # TODO
     end
   end
 end

--- a/lib/generators/annotate_rb/hook/templates/annotate_rb.rake
+++ b/lib/generators/annotate_rb/hook/templates/annotate_rb.rake
@@ -4,5 +4,7 @@
 if Rails.env.development? && ENV["ANNOTATERB_SKIP_ON_DB_TASKS"].nil?
   require "annotate_rb"
 
+  # Can modify the config path here if needed - by default, it's .annotaterb.yml in the root of the project
+  # AnnotateRb::ConfigFinder.config_path = ""
   AnnotateRb::Core.load_rake_tasks
 end

--- a/spec/lib/annotate_rb/config_finder_spec.rb
+++ b/spec/lib/annotate_rb/config_finder_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe AnnotateRb::ConfigFinder do
+  describe ".find_project_dotfile" do
+    subject { described_class.find_project_dotfile }
+
+    context "when the config path directory is set" do
+      before {
+        allow(File).to receive(:exist?).and_return(true)
+        described_class.config_path = "spec/fixtures/.annotaterb.yml"
+      }
+      after { described_class.config_path = nil }
+
+      it "returns the config path" do
+        expect(subject).to eq("spec/fixtures/.annotaterb.yml")
+      end
+    end
+
+    context "when the config path directory is not set" do
+      before { allow(File).to receive(:exist?).and_return(true) }
+
+      it "returns the default dotfile path" do
+        expect(subject).to eq(File.expand_path(".annotaterb.yml", Dir.pwd))
+      end
+    end 
+
+    context "when the config path directory is not set and the dotfile does not exist" do
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
In our company we're using this gem in monorepo - where there are multiple Rails applications and Rails engines. This PR allows to specify custom location for configuration file so it can be shared across multiple applications.