### PR TITLE
feat: identify unique indexes in simple_indexes option

### DIFF
--- a/lib/annotate_rb/model_annotator/column_annotation/attributes_builder.rb
+++ b/lib/annotate_rb/model_annotator/column_annotation/attributes_builder.rb
@@ -70,10 +70,16 @@ module AnnotateRb
             sorted_column_indices&.each do |index|
               indexed_columns = index.columns.reject { |i| i == @column.name }
 
-              attrs << if indexed_columns.empty?
-                "indexed"
+              index_text = if index.unique
+                "uniquely indexed"
               else
-                "indexed => [#{indexed_columns.join(", ")}]"
+                "indexed"
+              end
+
+              attrs << if indexed_columns.empty?
+                index_text
+              else
+                "#{index_text} => [#{indexed_columns.join(", ")}]"
               end
             end
           end

--- a/spec/lib/annotate_rb/model_annotator/column_annotation/attributes_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/column_annotation/attributes_builder_spec.rb
@@ -153,6 +153,19 @@ RSpec.describe AnnotateRb::ModelAnnotator::ColumnAnnotation::AttributesBuilder d
 
         it { is_expected.to match_array(expected_result) }
       end
+
+      context "with a column including an index with a unique constraint" do
+        let(:column) { mock_column("name", :string) }
+        let(:expected_result) { ["not null", "primary key", "uniquely indexed"] }
+
+        let(:column_indices) do
+          [
+            mock_index("index_rails_02e851e3b8", columns: ["name"], unique: true)
+          ]
+        end
+
+        it { is_expected.to match_array(expected_result) }
+      end
     end
 
     context "when the hide_default_column_types option is 'skip' with a json column" do


### PR DESCRIPTION
When generating simple indexes, there is no identifier for unique indexes. This PR updates the `simple_index` option to annotate with `uniquely indexed` for unique indexes.

Screenshot from a project I tested with:
![image](https://github.com/user-attachments/assets/7647959e-1cc9-41d5-bd9d-134a96404dee)