### PR TITLE
Cache retrieved indexes in ModelWrapper

### DIFF
--- a/lib/annotate_rb/model_annotator/model_wrapper.rb
+++ b/lib/annotate_rb/model_annotator/model_wrapper.rb
@@ -109,6 +109,10 @@ module AnnotateRb
       end
 
       def retrieve_indexes_from_table
+        @indexes_from_table ||= _retrieve_indexes_from_table
+      end
+
+      def _retrieve_indexes_from_table
         table_name = @klass.table_name
         return [] unless table_name
 


### PR DESCRIPTION
When upgrading rails project with 200+ models from annotate to this gem (thanks for creating and maintaining it!), we noticed that annotation became a lot slower. We managed to pinpoint the problem to `indexes = @klass.connection.indexes(table_name)` which was invoked from `AnnotationBuilder::Annotation#columns`  for every column of every model.

Original annotate:
```
bundle exec annotate --models  7,72s user 0,82s system 68% cpu 12,553 total
```
Before this change:
```
bundle exec annotaterb models  27,14s user 2,19s system 60% cpu 48,816 total
```
After this change:
```
bundle exec annotaterb models  7,22s user 0,82s system 82% cpu 9,748 total
```