### PR TITLE
Add debug logs for model annotation

### DIFF
--- a/lib/annotate_rb/model_annotator/project_annotator.rb
+++ b/lib/annotate_rb/model_annotator/project_annotator.rb
@@ -34,6 +34,7 @@ module AnnotateRb
       private
 
       def build_instructions_for_file(file)
+        start = Time.now
         klass = ModelClassGetter.call(file, @options)
 
         instructions = []
@@ -51,6 +52,10 @@ module AnnotateRb
           _instruction = SingleFileAnnotatorInstruction.new(f, annotation, position_key, @options)
         end
         instructions.concat(related_file_instructions)
+
+        if @options[:debug]
+          puts "Built instructions for #{file} in #{Time.now - start}s"
+        end
 
         instructions
       end


### PR DESCRIPTION
We have a pretty large monolith (as well as a second database host that tends to get bogged down after it runs for a while in development), so we find it useful to see some progress indicator while annotations are running.

This adds them in for each model when debug is set. This uses `puts` to match the current debug log that exists.