### PR TITLE
Move activerecord dependency into gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,12 +6,13 @@ gemspec
 
 gem "activerecord", require: false
 gem "rake"
-gem "rspec"
 
 group :development, :test do
   gem "aruba", "~> 2.1.0", require: false
   gem "byebug"
   gem "guard-rspec", require: false
+
+  gem "rspec"
 
   gem "standard", "~> 1.29.0"
   gem "terminal-notifier-guard", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source "https://rubygems.org"
 gemspec
 
 gem "activerecord", require: false
-gem "rake"
 
 group :development, :test do
   gem "aruba", "~> 2.1.0", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,6 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "activerecord", require: false
-
 group :development, :test do
   gem "aruba", "~> 2.1.0", require: false
   gem "byebug"

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "rake"
+
 group :development, :test do
   gem "aruba", "~> 2.1.0", require: false
   gem "byebug"

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source "https://rubygems.org"
 
+gemspec
+
 gem "activerecord", require: false
 gem "rake"
 gem "rspec"
@@ -19,5 +21,3 @@ group :development, :test do
     gem "pry-byebug", require: false
   end
 end
-
-gemspec

--- a/annotaterb.gemspec
+++ b/annotaterb.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = Dir["exe/*"].map { |exe| File.basename(exe) }
   spec.require_paths = ["lib"]
+
+  spec.add_dependency "activerecord", ">= 6.0.0"
 end

--- a/annotaterb.gemspec
+++ b/annotaterb.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activerecord", ">= 6.0.0"
+  spec.add_dependency "activesupport", ">= 6.0.0"
 end


### PR DESCRIPTION
Moves dependencies from Gemfile into gemspec file. Makes the dependency on activesupport explicit.