### PR TITLE
Pass .annotaterb.yml through ERB

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -88,6 +88,16 @@ This change was done to reduce complexity in configuration and make the gem easi
 
 ----------
 
+### Dynamic configuration settings
+
+`.annotaterb.yml` is passed through ERB. Therefore, if your previous settings had dynamic values, you can still replicate that logic in the new configuration file:
+
+```yaml
+model_dir: <%= Dir["packs/*/app/models"].inspect %>
+```
+
+----------
+
 ### Automatic annotations after running database migration commands
 The old Annotate gem came with a generator that installed the following Rake file(s) into your Rails project.
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Previously in the [Annotate](https://github.com/ctran/annotate_models) you could
 position: after
 ```
 
-Annotaterb reads first from the configuration file, if it exists, then merges it with any options passed into the CLI. 
+Annotaterb reads first the configuration file, if it exists, passes its content through ERB, and merges the result with any options passed into the CLI.
 
 For further details visit the [section in the migration guide](MIGRATION_GUIDE.md#automatic-annotations-after-running-database-migration-commands).
 

--- a/lib/annotate_rb/config_loader.rb
+++ b/lib/annotate_rb/config_loader.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'erb'
+
 module AnnotateRb
   # Raised when a configuration file is not found.
   class ConfigNotFoundError < StandardError
@@ -20,8 +22,9 @@ module AnnotateRb
       # Method from Rubocop::ConfigLoader
       def load_yaml_configuration(absolute_path)
         file_contents = read_file(absolute_path)
+        yaml_code = ERB.new(file_contents).result
 
-        hash = yaml_safe_load(file_contents, absolute_path) || {}
+        hash = yaml_safe_load(yaml_code, absolute_path) || {}
 
         # TODO: Print config if debug flag/option is set
 

--- a/lib/annotate_rb/config_loader.rb
+++ b/lib/annotate_rb/config_loader.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'erb'
+require "erb"
 
 module AnnotateRb
   # Raised when a configuration file is not found.

--- a/spec/lib/annotate_rb/config_loader_spec.rb
+++ b/spec/lib/annotate_rb/config_loader_spec.rb
@@ -1,0 +1,53 @@
+require 'tempfile'
+
+RSpec.describe AnnotateRb::ConfigLoader do
+  before do
+    expect(AnnotateRb::ConfigFinder).to receive(:find_project_dotfile).and_return(dotfile)
+  end
+
+  describe ".load_config" do
+    subject { described_class.load_config }
+
+    context "there is no config file" do
+      let(:dotfile) { nil }
+
+      it { is_expected.to eq({})}
+    end
+
+    context "there is a plain config file" do
+      let(:tempfile) { Tempfile.new('annotaterb') }
+      let(:dotfile) { tempfile.path }
+
+      around do |example|
+        File.write(tempfile.path, <<~YAML)
+          :model_dir:
+          - app/models
+        YAML
+        example.run
+        tempfile.unlink
+      end
+
+      it "reads the dotfile successfully" do
+        expect(subject[:model_dir]).to eq(["app/models"])
+      end
+    end
+
+    context "the config file has ERB in it" do
+      let(:tempfile) { Tempfile.new('annotaterb') }
+      let(:dotfile) { tempfile.path }
+
+      around do |example|
+        File.write(tempfile.path, <<~YAML)
+          <% model_dir = %w(foo/models bar/models baz/models) %>
+          :model_dir: <%= model_dir.inspect %>
+        YAML
+        example.run
+        tempfile.unlink
+      end
+
+      it "reads the dotfile successfully" do
+        expect(subject[:model_dir]).to eq(%w(foo/models bar/models baz/models))
+      end
+    end
+  end
+end

--- a/spec/lib/annotate_rb/config_loader_spec.rb
+++ b/spec/lib/annotate_rb/config_loader_spec.rb
@@ -1,4 +1,4 @@
-require 'tempfile'
+require "tempfile"
 
 RSpec.describe AnnotateRb::ConfigLoader do
   before do
@@ -11,11 +11,11 @@ RSpec.describe AnnotateRb::ConfigLoader do
     context "there is no config file" do
       let(:dotfile) { nil }
 
-      it { is_expected.to eq({})}
+      it { is_expected.to eq({}) }
     end
 
     context "there is a plain config file" do
-      let(:tempfile) { Tempfile.new('annotaterb') }
+      let(:tempfile) { Tempfile.new("annotaterb") }
       let(:dotfile) { tempfile.path }
 
       around do |example|
@@ -33,12 +33,12 @@ RSpec.describe AnnotateRb::ConfigLoader do
     end
 
     context "the config file has ERB in it" do
-      let(:tempfile) { Tempfile.new('annotaterb') }
+      let(:tempfile) { Tempfile.new("annotaterb") }
       let(:dotfile) { tempfile.path }
 
       around do |example|
         File.write(tempfile.path, <<~YAML)
-          <% model_dir = %w(foo/models bar/models baz/models) %>
+          <% model_dir = %w[foo/models bar/models baz/models] %>
           :model_dir: <%= model_dir.inspect %>
         YAML
         example.run
@@ -46,7 +46,7 @@ RSpec.describe AnnotateRb::ConfigLoader do
       end
 
       it "reads the dotfile successfully" do
-        expect(subject[:model_dir]).to eq(%w(foo/models bar/models baz/models))
+        expect(subject[:model_dir]).to eq(%w[foo/models bar/models baz/models])
       end
     end
   end


### PR DESCRIPTION
Hi!

This PR proposes passing `.annotaterb.yml` through ERB, as Rails does with `config/database.yml` or fixtures, for instance.

Real use case is the ability to compute `model_dir` dynamically. As you know, in `annotate` the configuration can be expressed in Ruby, and therefore it can be as dynamic as you need to. But if you migrate to `annotaterb`, that is lost.

I wrote this patch on behalf of a client of mine (Gusto), whose main application has more than two hundred model dirs. They are now hard-coded in `.annotaterb.yml`, but you need to maintain that list, verify consistency in CI, etc. On the other hand, if you could compute the list in the config file itself, you could forget about it (as it was the case with `annotate`).

I have created a test suite for `load_config`, and documentation is also updated (README and migration guide). The variable `yaml_code` is named after the parameter in the signature of the called method.

The CHANGELOG seems more ad-hoc, maybe you prefer to modify this one? Please just tell me if you'd like me to do it anyway :).
