### PR TITLE
Refactor column ignore to use `match?`

### DIFF
--- a/lib/annotate_rb/model_annotator/model_wrapper.rb
+++ b/lib/annotate_rb/model_annotator/model_wrapper.rb
@@ -23,7 +23,7 @@ module AnnotateRb
             ignore_columns = @options[:ignore_columns]
             if ignore_columns
               cols = cols.reject do |col|
-                col.name.match(/#{ignore_columns}/)
+                col.name.match?(/#{ignore_columns}/)
               end
             end
 


### PR DESCRIPTION
Switch from `match` to `match?` when filtering out ignored columns, as only the boolean result is needed.

This improves clarity and performance by avoiding unnecessary creation of `MatchData` objects.