### PR TITLE
Add AnnotateRb::Runner.running? method

### DIFF
--- a/lib/annotate_rb/runner.rb
+++ b/lib/annotate_rb/runner.rb
@@ -3,9 +3,23 @@
 module AnnotateRb
   class Runner
     class << self
+      attr_reader :runner
+
       def run(args)
-        new.run(args)
+        self.runner = new
+
+        runner.run(args)
+
+        self.runner = nil
       end
+
+      def running?
+        !!runner
+      end
+
+      private
+
+      attr_writer :runner
     end
 
     def run(args)

--- a/spec/lib/annotate_rb/runner_spec.rb
+++ b/spec/lib/annotate_rb/runner_spec.rb
@@ -84,4 +84,30 @@ RSpec.describe AnnotateRb::Runner do
       expect(command_double).to have_received(:call)
     end
   end
+
+  describe ".running?" do
+    context "when an instance is not running" do
+      it "is false" do
+        expect(AnnotateRb::Runner).not_to be_running
+      end
+    end
+
+    context "when an instance is running" do
+      it "is true" do
+        expect(AnnotateRb::Runner).not_to be_running
+
+        double = instance_double(described_class)
+
+        allow(described_class).to receive(:new).and_return(double)
+
+        expect(double).to receive(:run) do |original_method, *args|
+          expect(AnnotateRb::Runner).to be_running
+
+          true
+        end
+
+        AnnotateRb::Runner.run({})
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is so that we can facilitate dynamic logic during the annotation process.

This is something that the historical `annotate_models` gem provided, via `Annotate::Migration.class_variable_get(:@@working))`

https://github.com/ctran/annotate_models/blob/5d01c4171990c4fe7b9b0977b05ce14a98209e53/lib/tasks/annotate_models_migrate.rake#L36-L41

Instead of having to reach into the Migration class, this instead stores some state on the `AnnotateRb::Runner` class so that we can ask it directly if it's in the middle of running.