### PR TITLE
Speed up AnnotationDecider

### DIFF
--- a/lib/annotate_rb/model_annotator/annotation_decider.rb
+++ b/lib/annotate_rb/model_annotator/annotation_decider.rb
@@ -18,7 +18,7 @@ module AnnotateRb
           klass = ModelClassGetter.call(@file, @options)
           return false unless klass.respond_to?(:descends_from_active_record?) && klass.descends_from_active_record? && klass.table_exists?
 
-          @options[:exclude_sti_subclasses] ? true : !klass.base_class?
+          @options[:exclude_sti_subclasses] ? klass.base_class? : true
         rescue BadModelFileError => e
           unless @options[:ignore_unknown_models]
             warn "Unable to process #{@file}: #{e.message}"

--- a/lib/annotate_rb/model_annotator/annotation_decider.rb
+++ b/lib/annotate_rb/model_annotator/annotation_decider.rb
@@ -18,7 +18,7 @@ module AnnotateRb
           klass = ModelClassGetter.call(@file, @options)
           return false unless klass.respond_to?(:descends_from_active_record?) && klass.descends_from_active_record? && klass.table_exists?
 
-          @options[:exclude_sti_subclasses] ? klass.base_class? : true
+          return @options[:exclude_sti_subclasses] ? klass.base_class? : true
         rescue BadModelFileError => e
           unless @options[:ignore_unknown_models]
             warn "Unable to process #{@file}: #{e.message}"

--- a/lib/annotate_rb/model_annotator/annotation_decider.rb
+++ b/lib/annotate_rb/model_annotator/annotation_decider.rb
@@ -17,28 +17,13 @@ module AnnotateRb
         begin
           klass = ModelClassGetter.call(@file, @options)
 
-          klass_is_a_class = klass.is_a?(Class)
-          # Methods such as #superclass only exist on a class. Because of how the code is structured, `klass` could be a
-          #  module that does not support the #superclass method, so we want to return early.
-          return false if !klass_is_a_class
+          return false unless klass.is_a?(Class)
+          return false unless klass < ActiveRecord::Base
+          return false unless klass.respond_to?(:abstract_class?) && !klass.abstract_class?
+          return false unless klass.respond_to?(:table_exists?) && klass.table_exists?
+          return false unless !@options[:exclude_sti_subclasses] || !(klass.superclass < ActiveRecord::Base && klass.table_name == klass.superclass.table_name)
 
-          klass_inherits_active_record_base = klass < ActiveRecord::Base
-          klass_is_not_abstract = klass.respond_to?(:abstract_class?) && !klass.abstract_class?
-          klass_table_exists = klass.respond_to?(:table_exists?) && klass.table_exists?
-
-          not_sure_this_conditional = (!@options[:exclude_sti_subclasses] || !(klass.superclass < ActiveRecord::Base && klass.table_name == klass.superclass.table_name))
-
-          annotate_conditions = [
-            klass_is_a_class,
-            klass_inherits_active_record_base,
-            not_sure_this_conditional,
-            klass_is_not_abstract,
-            klass_table_exists
-          ]
-
-          to_annotate = annotate_conditions.all?
-
-          return to_annotate
+          true
         rescue BadModelFileError => e
           unless @options[:ignore_unknown_models]
             warn "Unable to process #{@file}: #{e.message}"
@@ -55,9 +40,9 @@ module AnnotateRb
       private
 
       def file_contains_skip_annotation
-        file_string = File.exist?(@file) ? File.read(@file) : ""
+        return false unless File.exist?(@file)
 
-        /#{SKIP_ANNOTATION_PREFIX}.*/o.match?(file_string)
+        /#{SKIP_ANNOTATION_PREFIX}.*/o.match?(File.read(@file))
       end
     end
   end

--- a/lib/annotate_rb/model_annotator/annotation_decider.rb
+++ b/lib/annotate_rb/model_annotator/annotation_decider.rb
@@ -16,14 +16,9 @@ module AnnotateRb
 
         begin
           klass = ModelClassGetter.call(@file, @options)
+          return false unless klass.respond_to?(:descends_from_active_record?) && klass.descends_from_active_record? && klass.table_exists?
 
-          return false unless klass.is_a?(Class)
-          return false unless klass < ActiveRecord::Base
-          return false unless klass.respond_to?(:abstract_class?) && !klass.abstract_class?
-          return false unless klass.respond_to?(:table_exists?) && klass.table_exists?
-          return false unless !@options[:exclude_sti_subclasses] || !(klass.superclass < ActiveRecord::Base && klass.table_name == klass.superclass.table_name)
-
-          true
+          @options[:exclude_sti_subclasses] ? true : !klass.base_class?
         rescue BadModelFileError => e
           unless @options[:ignore_unknown_models]
             warn "Unable to process #{@file}: #{e.message}"


### PR DESCRIPTION
While looking for a fix for #172 I noticed that `AnnotationDecider` does a fair amount of checks before checking that _all_ are true. We can speed up the decision making a bit and avoid the current issue with `AssociatedObject` completely if we return false early whenever a check fails instead of collecting all the results and then returning false.  It's not the prettiest code but it works and is faster (slightly) on a benchmark:

```
Comparison:
NewAnnotationDecider#annotate?:          30189.7 i/s
OriginalAnnotationDecider#annotate?:    18295.3 i/s - 1.65x  slower
```

I'm aware that the issue posted in #172 Is actually an issue with the `AssociatedObject` gem so no worries if you don't want to merge this.