### PR TITLE
Run on rollback in app with multiple databases

### DIFF
--- a/lib/annotate_rb/tasks/annotate_models_migrate.rake
+++ b/lib/annotate_rb/tasks/annotate_models_migrate.rake
@@ -18,7 +18,7 @@ if defined?(Rails::Application) && Rails.version.split(".").first.to_i >= 6
 
   # If there's multiple databases, this appends database specific rake tasks to `migration_tasks`
   ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |database_name|
-    migration_tasks.concat(%w[db:migrate db:migrate:up db:migrate:down].map { |task| "#{task}:#{database_name}" })
+    migration_tasks.concat(%w[db:migrate db:migrate:up db:migrate:down db:rollback].map { |task| "#{task}:#{database_name}" })
   end
 end
 

--- a/spec/lib/tasks/annotate_models_migrate_spec.rb
+++ b/spec/lib/tasks/annotate_models_migrate_spec.rb
@@ -1,63 +1,126 @@
 RSpec.describe "ActiveRecord migration rake task hooks" do
-  before do
-    Rake.application = Rake::Application.new
+  context "single database" do
+    before do
+      Rake.application = Rake::Application.new
 
-    # Stub migration tasks
-    %w[db:migrate db:migrate:up db:migrate:down db:migrate:reset db:rollback].each do |task|
-      Rake::Task.define_task(task)
+      # Stub migration tasks
+      %w[db:migrate db:migrate:up db:migrate:down db:migrate:reset db:rollback].each do |task|
+        Rake::Task.define_task(task)
+      end
+
+      Rake::Task.define_task("db:migrate:redo") do
+        Rake::Task["db:rollback"].invoke
+        Rake::Task["db:migrate"].invoke
+      end
+
+      Rake.load_rakefile("annotate_rb/tasks/annotate_models_migrate.rake")
+
+      Rake.application.instance_variable_set(:@top_level_tasks, [subject])
     end
 
-    Rake::Task.define_task("db:migrate:redo") do
-      Rake::Task["db:rollback"].invoke
-      Rake::Task["db:migrate"].invoke
+    describe "db:migrate" do
+      it "should annotate model files" do
+        expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models"))
+        Rake.application.top_level
+      end
     end
 
-    Rake.load_rakefile("annotate_rb/tasks/annotate_models_migrate.rake")
+    describe "db:migrate:up" do
+      it "should annotate model files" do
+        expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models"))
+        Rake.application.top_level
+      end
+    end
 
-    Rake.application.instance_variable_set(:@top_level_tasks, [subject])
+    describe "db:migrate:down" do
+      it "should annotate model files" do
+        expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models"))
+        Rake.application.top_level
+      end
+    end
+
+    describe "db:migrate:reset" do
+      it "should annotate model files" do
+        expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models"))
+        Rake.application.top_level
+      end
+    end
+
+    describe "db:rollback" do
+      it "should annotate model files" do
+        expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models"))
+        Rake.application.top_level
+      end
+    end
+
+    describe "db:migrate:redo" do
+      it "should annotate model files after all migration tasks" do
+        # Hooked 3 times by db:rollback, db:migrate, and db:migrate:redo tasks
+        expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models")).exactly(3).times
+
+        Rake.application.top_level
+      end
+    end
   end
 
-  describe "db:migrate" do
-    it "should annotate model files" do
-      expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models"))
-      Rake.application.top_level
+  context "multiple databases" do
+    def stub_rails(version, database_names)
+      stub_const("Rails::Application", Class.new)
+      allow(Rails).to receive(:version).and_return(version)
+
+      stub_const("ActiveRecord::Tasks::DatabaseTasks", Module.new)
+
+      allow(ActiveRecord::Tasks::DatabaseTasks).to receive(:setup_initial_database_yaml) do
+        database_names.index_with do
+          {}
+        end
+      end
+
+      allow(ActiveRecord::Tasks::DatabaseTasks).to receive(:for_each) do |databases, &block|
+        databases.each { |name, config| block.call(name) }
+      end
     end
-  end
 
-  describe "db:migrate:up" do
-    it "should annotate model files" do
-      expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models"))
-      Rake.application.top_level
+    before do
+      stub_rails "6.0.0", ["primary"]
+
+      Rake.application = Rake::Application.new
+
+      %w[db:migrate db:migrate:up db:migrate:down db:rollback].each do |task|
+        Rake::Task.define_task("#{task}:primary")
+      end
+
+      Rake.load_rakefile("annotate_rb/tasks/annotate_models_migrate.rake")
+
+      Rake.application.instance_variable_set(:@top_level_tasks, [subject])
     end
-  end
 
-  describe "db:migrate:down" do
-    it "should annotate model files" do
-      expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models"))
-      Rake.application.top_level
+    describe "db:migrate:primary" do
+      it "should annotate model files" do
+        expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models"))
+        Rake.application.top_level
+      end
     end
-  end
 
-  describe "db:migrate:reset" do
-    it "should annotate model files" do
-      expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models"))
-      Rake.application.top_level
+    describe "db:migrate:up:primary" do
+      it "should annotate model files" do
+        expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models"))
+        Rake.application.top_level
+      end
     end
-  end
 
-  describe "db:rollback" do
-    it "should annotate model files" do
-      expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models"))
-      Rake.application.top_level
+    describe "db:migrate:down:primary" do
+      it "should annotate model files" do
+        expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models"))
+        Rake.application.top_level
+      end
     end
-  end
 
-  describe "db:migrate:redo" do
-    it "should annotate model files after all migration tasks" do
-      # Hooked 3 times by db:rollback, db:migrate, and db:migrate:redo tasks
-      expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models")).exactly(3).times
-
-      Rake.application.top_level
+    describe "db:rollback:primary" do
+      it "should annotate model files" do
+        expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models"))
+        Rake.application.top_level
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #244.

I started out writing a spec for the Rake file, then realized that would depend on Rails being loaded, but an integration test felt awfully heavy and involved. I opted to update the Rake specs to support stubbing the Rails interfaces it relies on.