### PR TITLE
Return a model files array even if it’s empty

### DIFF
--- a/lib/annotate_rb/model_annotator/model_files_getter.rb
+++ b/lib/annotate_rb/model_annotator/model_files_getter.rb
@@ -32,9 +32,8 @@ module AnnotateRb
             warn "Either specify models on the command line, or use the --model-dir option."
             warn "Call 'annotaterb --help' for more info."
             # exit 1 # TODO: Return exit code back to caller. Right now it messes up RSpec being able to run
-          else
-            model_files
           end
+          model_files
         end
 
         private

--- a/spec/lib/annotate_rb/model_annotator/model_files_getter_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/model_files_getter_spec.rb
@@ -93,6 +93,10 @@ RSpec.describe AnnotateRb::ModelAnnotator::ModelFilesGetter do
         subject
         expect($stderr.string).to include("No models found in directory")
       end
+
+      it "returns an empty array" do
+        expect(subject).to be_empty
+      end
     end
 
     context "when `model_dir` is the glob pattern" do


### PR DESCRIPTION
Currently, when there are no available models, `ModelFilesGetter` returns `nil` but callers are expecting it to return an array.

This makes the app crash with:
```
/home/discourse/.bundle/gems/ruby/3.3.0/gems/annotaterb-4.17.0/lib/annotate_rb/model_annotator/project_annotator.rb:13:in `annotate': undefined method `map' for nil (NoMethodError)

        annotation_instructions = project_model_files.map do |path, filename|
                                                     ^^^^
        from /home/discourse/.bundle/gems/ruby/3.3.0/gems/annotaterb-4.17.0/lib/annotate_rb/model_annotator/annotator.rb:21:in `do_annotations'
        from /home/discourse/.bundle/gems/ruby/3.3.0/gems/annotaterb-4.17.0/lib/annotate_rb/model_annotator/annotator.rb:8:in `do_annotations'
        from /home/discourse/.bundle/gems/ruby/3.3.0/gems/annotaterb-4.17.0/lib/annotate_rb/commands/annotate_models.rb:17:in `call'
        from /home/discourse/.bundle/gems/ruby/3.3.0/gems/annotaterb-4.17.0/lib/annotate_rb/runner.rb:24:in `run'
        from /home/discourse/.bundle/gems/ruby/3.3.0/gems/annotaterb-4.17.0/lib/annotate_rb/runner.rb:7:in `run'
        from /home/discourse/.bundle/gems/ruby/3.3.0/gems/annotaterb-4.17.0/exe/annotaterb:18:in `<top (required)>'
        from bin/annotaterb:27:in `load'
        from bin/annotaterb:27:in `<main>'
```

This patch just make sure `ModelFilesGetter` always return an array.