### PR TITLE
refactor: relocate migration_version_for_model method to ModelWrapper

### DIFF
--- a/lib/annotate_rb/model_annotator/annotation/annotation_builder.rb
+++ b/lib/annotate_rb/model_annotator/annotation/annotation_builder.rb
@@ -59,7 +59,7 @@ module AnnotateRb
         end
 
         def build
-          version = migration_version_for_model(@model)
+          version = @model.migration_version
           table_name = @model.table_name
           table_comment = @model.connection.try(:table_comment, @model.table_name)
           max_size = @model.max_schema_info_width
@@ -67,30 +67,6 @@ module AnnotateRb
           _annotation = Annotation.new(@options,
             version: version, table_name: table_name, table_comment: table_comment,
             max_size: max_size, model: @model).build
-        end
-
-        private
-
-        def migration_version_for_model(model)
-          return 0 unless @options[:include_version]
-
-          # Multi-database support: Cache migration versions per database connection to handle
-          # different schema versions across primary/secondary databases correctly.
-          # Example: primary → "current_version_primary", secondary → "current_version_secondary"
-          connection_pool_name = model.connection.pool.db_config.name
-          cache_key = "current_version_#{connection_pool_name}".to_sym
-
-          if @options.get_state(cache_key).nil?
-            migration_version = begin
-              model.connection.migration_context.current_version
-            rescue
-              0
-            end
-
-            @options.set_state(cache_key, migration_version)
-          end
-
-          @options.get_state(cache_key)
         end
       end
     end


### PR DESCRIPTION
I really appreciate you taking the time to maintain this project.

Refactored by moving the method added in #241 to the ModelWrapper class for the following reasons:
- Moves migration version retrieval and caching logic to ModelWrapper
- Improves code organization by centralizing database connection operations
- Maintains existing multi-database caching behavior with connection pool names
- Enhances consistency with other database-related methods in ModelWrapper

No functional changes.