### PR TITLE
chore: introduce switchable DB environment for specs

### DIFF
--- a/spec/dummyapp/config/database.yml
+++ b/spec/dummyapp/config/database.yml
@@ -11,10 +11,12 @@
     primary:
       <<: *default
       database: annotaterb_development
+    <% unless ENV['SINGLE_DB_TEST'] == 'true' %>
     secondary:
       <<: *default
       database: secondary_annotaterb_development
       migrations_paths: db/secondary_migrate
+    <% end %>
 <% end %>
 
 <% if ENV['DATABASE_ADAPTER'] == 'pg' %>
@@ -30,10 +32,12 @@
     primary:
       <<: *default
       database: annotaterb_development
+    <% unless ENV['SINGLE_DB_TEST'] == 'true' %>
     secondary:
       <<: *default
       database: secondary_annotaterb_development
       migrations_paths: db/secondary_migrate
+    <% end %>
 <% end %>
 
 <% if ENV['DATABASE_ADAPTER'] == 'sqlite3' %>
@@ -44,8 +48,10 @@
     primary:
       <<: *default
       database: db/development.sqlite3
+    <% unless ENV['SINGLE_DB_TEST'] == 'true' %>
     secondary:
       <<: *default
       database: secondary_annotaterb_development
       migrations_paths: db/secondary_migrate
+    <% end %>
 <% end %>

--- a/spec/support/database_contexts.rb
+++ b/spec/support/database_contexts.rb
@@ -1,0 +1,9 @@
+# Use this shared context to run specs in a simulated single-database environment.
+#
+# This sets the `SINGLE_DB_TEST` environment variable, which is used by the
+# dummy app's `database.yml` to exclude the secondary database.
+RSpec.shared_context "when in a single database environment" do
+  before do
+    set_environment_variable("SINGLE_DB_TEST", "true")
+  end
+end


### PR DESCRIPTION
### Summary
This commit enhances the RSpec test environment to support both single and multi-database configurations.

### Problem
The next feature to be implemented is conditional model annotations, which requires asserting behavior in two different scenarios:

1. The annotation is added in a multi-DB environment.
2. The annotation is not added in a single-DB environment.

The existing test suite only supported a multi-DB setup, making it impossible to validate the second scenario.

### Solution
- The database.yml for the dummy app is updated to use an environment variable (SINGLE_DB_TEST). This allows it to conditionally exclude the secondary database configuration.
- A new RSpec shared_context ("when in a single database environment") is introduced. This provides specs with a clean, reusable way to enable the single-database mode for testing.

Refs #254