### PR TITLE
refactor(test): Default to single-DB environment for tests

### DIFF
--- a/spec/dummyapp/config/database.yml
+++ b/spec/dummyapp/config/database.yml
@@ -11,7 +11,7 @@
     primary:
       <<: *default
       database: annotaterb_development
-    <% unless ENV['SINGLE_DB_TEST'] == 'true' %>
+    <% if ENV['MULTI_DB_TEST'] == 'true' %>
     secondary:
       <<: *default
       database: secondary_annotaterb_development
@@ -32,7 +32,7 @@
     primary:
       <<: *default
       database: annotaterb_development
-    <% unless ENV['SINGLE_DB_TEST'] == 'true' %>
+    <% if ENV['MULTI_DB_TEST'] == 'true' %>
     secondary:
       <<: *default
       database: secondary_annotaterb_development
@@ -48,7 +48,7 @@
     primary:
       <<: *default
       database: db/development.sqlite3
-    <% unless ENV['SINGLE_DB_TEST'] == 'true' %>
+    <% if ENV['MULTI_DB_TEST'] == 'true' %>
     secondary:
       <<: *default
       database: secondary_annotaterb_development

--- a/spec/integration/annotate_after_migration_spec.rb
+++ b/spec/integration/annotate_after_migration_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Annotate after running migrations", type: "aruba" do
     copy(File.join(migrations_template_dir, migration_file), "db/migrate")
 
     # Apply this specific migration
-    _run_migrations_cmd = run_command_and_stop("bin/rails db:migrate:up:primary VERSION=20231013230731", fail_on_error: true, exit_timeout: command_timeout_seconds)
+    _run_migrations_cmd = run_command_and_stop("bin/rails db:migrate:up VERSION=20231013230731", fail_on_error: true, exit_timeout: command_timeout_seconds)
     _run_annotations_cmd = run_command_and_stop("bundle exec annotaterb models", fail_on_error: true, exit_timeout: command_timeout_seconds)
 
     annotated_test_default = read_file(dummyapp_model("test_default.rb"))

--- a/spec/integration/annotate_models_in_multi_db_spec.rb
+++ b/spec/integration/annotate_models_in_multi_db_spec.rb
@@ -3,6 +3,8 @@
 require "integration_spec_helper"
 
 RSpec.describe "Annotate models in a multi-db environment with duplicate table names", type: "aruba" do
+  include_context "when in a multi database environment"
+
   let(:command_timeout_seconds) { 10 }
 
   # Test that running `bundle exec annotate models` twice results in no changes on the second run

--- a/spec/integration/annotate_with_show_migration_option_spec.rb
+++ b/spec/integration/annotate_with_show_migration_option_spec.rb
@@ -3,6 +3,8 @@
 require "integration_spec_helper"
 
 RSpec.describe "Annotate with --show-migration option", type: "aruba" do
+  include_context "when in a multi database environment"
+
   let(:command_timeout_seconds) { 10 }
   let(:model_file) { "app/models/test_default.rb" }
 

--- a/spec/support/database_contexts.rb
+++ b/spec/support/database_contexts.rb
@@ -1,9 +1,9 @@
-# Use this shared context to run specs in a simulated single-database environment.
+# Use this shared context to run specs in a simulated multi-database environment.
 #
-# This sets the `SINGLE_DB_TEST` environment variable, which is used by the
-# dummy app's `database.yml` to exclude the secondary database.
-RSpec.shared_context "when in a single database environment" do
+# This sets the `MULTI_DB_TEST` environment variable, which is used by the
+# dummy app's `database.yml` to include the secondary database configuration.
+RSpec.shared_context "when in a multi database environment" do
   before do
-    set_environment_variable("SINGLE_DB_TEST", "true")
+    set_environment_variable("MULTI_DB_TEST", "true")
   end
 end


### PR DESCRIPTION
This reverts the testing strategy introduced in #262, switching the default test environment from multi-DB back to single-DB.

### Problem

While PR #262 attempted to make testing for multi-DB environments the default, this approach had several drawbacks:

1.  **Wide-ranging Impact:** It required modifications to a large number of existing specs that do not actually need a multi-DB setup, increasing the scope of changes unnecessarily.
2.  **Unintuitive Logic:** The `unless ENV[...]` logic in `database.yml` to control the environment was not intuitive.
3.  **High Maintenance Cost:** It would have required future developers to be aware of this "multi-DB first" convention, adding unnecessary cognitive load.

### Solution

This commit implements a simpler and safer strategy:

- The test environment now **defaults to a single-database configuration.**
- The `database.yml` is updated to use a more explicit `if ENV['MULTI_DB_TEST'] == 'true'` to enable the
multi-DB setup **on an opt-in basis.**
- A `shared_context` ("when in a multi database environment") is provided for the few tests that
specifically require a multi-database setup.

This approach keeps the default test environment simple, minimizes the impact on the overall test suite, and makes the intention clearer for future developers.

Refs #254

Thank you for always maintaining it. 🚀 