### PR TITLE
Make it possible to filter files by Regexp

### DIFF
--- a/lib/annotate_rb/model_annotator/model_files_getter.rb
+++ b/lib/annotate_rb/model_annotator/model_files_getter.rb
@@ -27,6 +27,11 @@ module AnnotateRb
             end
           end
 
+          if options[:ignore_filename_regexp]
+            regexp = Regexp.new(options[:ignore_filename_regexp])
+            model_files.reject! { |_, file| File.basename(file).match?(regexp) }
+          end
+
           if model_files.empty?
             warn "No models found in directory '#{options[:model_dir].join("', '")}'."
             warn "Either specify models on the command line, or use the --model-dir option."

--- a/lib/annotate_rb/options.rb
+++ b/lib/annotate_rb/options.rb
@@ -90,6 +90,7 @@ module AnnotateRb
 
     PATH_OPTIONS = {
       additional_file_patterns: [], # ModelAnnotator
+      ignore_filename_regexp: nil, # ModelAnnotator
       model_dir: ["app/models"], # ModelAnnotator
       require: [], # Core
       root_dir: [""] # Core; Old model Annotate code depends on it being empty when not provided another value

--- a/spec/lib/annotate_rb/model_annotator/model_files_getter_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/model_files_getter_spec.rb
@@ -47,6 +47,18 @@ RSpec.describe AnnotateRb::ModelAnnotator::ModelFilesGetter do
             is_expected.to contain_exactly([model_dir, "foo.rb"])
           end
         end
+
+        context "when `ignore_file_regexp` option is enabled" do
+          let(:base_options) { {model_dir: [model_dir], ignore_filename_regexp: '\Aquux\.rb\z'} }
+          let(:options) { AnnotateRb::Options.new(base_options, {working_args: []}) }
+
+          it "returns model files that do not match the regexp" do
+            is_expected.to contain_exactly(
+              [model_dir, "foo.rb"],
+              [model_dir, File.join("bar", "baz.rb")],
+            )
+          end
+        end
       end
 
       context "when the model files are specified" do


### PR DESCRIPTION
Adds a new option that enables filtering model files by regexp.

Our use-case for this is filtering out spec files that live along side our models, for example we might have `user.rb` and `user.spec.rb` in the same directory.