### PR TITLE
fix: resolve YAML syntax error in update_config generator

### DIFF
--- a/lib/annotate_rb/config_generator.rb
+++ b/lib/annotate_rb/config_generator.rb
@@ -13,6 +13,9 @@ module AnnotateRb
         differences = defaults.keys - user_defaults.keys
         result = defaults.slice(*differences)
 
+        # Return empty string if no differences to avoid appending empty hash
+        return "" if result.empty?
+
         # Generates proper YAML including the leading hyphens `---` header
         yml_content = YAML.dump(result, StringIO.new).string
         # Remove the header

--- a/spec/lib/annotate_rb/config_generator_spec.rb
+++ b/spec/lib/annotate_rb/config_generator_spec.rb
@@ -17,4 +17,32 @@ RSpec.describe AnnotateRb::ConfigGenerator do
       expect(parsed).to include(**example_config_pair)
     end
   end
+
+  describe "#unset_config_defaults" do
+    subject { described_class.unset_config_defaults }
+
+    context "when user config has missing keys" do
+      before do
+        allow(AnnotateRb::ConfigLoader).to receive(:load_config).and_return({models: true})
+      end
+
+      it "returns yaml with missing defaults" do
+        expect(subject).to be_a(String)
+        expect(subject).not_to be_empty
+        expect(subject).not_to include("{}")
+      end
+    end
+
+    context "when user config has all default keys" do
+      before do
+        complete_config = AnnotateRb::Options.from({}, {}).to_h
+        allow(AnnotateRb::ConfigLoader).to receive(:load_config).and_return(complete_config)
+      end
+
+      it "returns empty string instead of empty hash" do
+        expect(subject).to eq("")
+        expect(subject).not_to include("{}")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hello! :wave: I was poking around the codebase and found this cool `update_config` generator. I gave it a run and found that it resulted in a YAML syntax error. So here's a quick fix!

## Problem

The `annotate_rb:update_config` generator was appending an empty hash `{}` to the configuration file when all default configuration keys were already present, causing a YAML syntax error.

**Before:**
```yaml
# [...] (A long list of defaults that were previously generated.)
:root_dir:
- '' {}
```

**After:**
```yaml
# [...] (The same list of defaults, minus the syntax error!)
:root_dir:
- ''
```

## Root Cause

In `lib/annotate_rb/config_generator.rb`, the `unset_config_defaults` method would:
1. Compare user config with defaults to find missing keys
2. Create a result hash with missing keys
3. When no keys were missing, `result` would be an empty hash `{}`
4. `YAML.dump({})` produces `--- {}\n` which gets appended to the config file

## Solution

Added an early return in `unset_config_defaults` to return empty string when no configuration differences exist:

```ruby
# Return empty string if no differences to avoid appending empty hash
return "" if result.empty?
```

## Test Coverage

Added some test coverage in `spec/lib/annotate_rb/config_generator_spec.rb`:
- Test for normal case (missing keys → returns YAML)
- Test for bug case (complete config → returns empty string, not `{}`)

I tried to reproduce the bug through the existing integration test case but I had trouble getting it set up and running locally. Otherwise, I'd love to validate that this code produces valid YAML!
