### PR TITLE
Honor skip_on_db_migrate config option when runnig migrate tasks

### DIFF
--- a/lib/annotate_rb/tasks/annotate_models_migrate.rake
+++ b/lib/annotate_rb/tasks/annotate_models_migrate.rake
@@ -22,8 +22,11 @@ if defined?(Rails::Application) && Rails.version.split(".").first.to_i >= 6
   end
 end
 
+config = ::AnnotateRb::ConfigLoader.load_config
+
 migration_tasks.each do |task|
   next unless Rake::Task.task_defined?(task)
+  next if config[:skip_on_db_migrate]
 
   Rake::Task[task].enhance do # This block is ran after `task` completes
     task_name = Rake.application.top_level_tasks.last # The name of the task that was run, e.g. "db:migrate"


### PR DESCRIPTION
Skip annotating on migration task when `skip_on_db_migrate` is set to `true`

Fixes https://github.com/drwl/annotaterb/issues/273