### PR TITLE
fix: position-of-column-comment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Annotate model options:
         --without-comment            exclude database comments in model annotations
         --with-column-comments       include column comments in model annotations
         --without-column-comments    exclude column comments in model annotations
-        --position-of-column-comments [with_name|rightmost_column]
+        --position-of-column-comment [with_name|rightmost_column]
                                      set the position, in the annotation block, of the column comment
         --with-table-comments        include table comments in model annotations
         --without-table-comments     exclude table comments in model annotations

--- a/lib/annotate_rb/parser.rb
+++ b/lib/annotate_rb/parser.rb
@@ -246,9 +246,9 @@ module AnnotateRb
         @options[:with_column_comments] = false
       end
 
-      option_parser.on("--position-of-column-comments [with_name|rightmost_column]",
+      option_parser.on("--position-of-column-comment [with_name|rightmost_column]",
         "set the position, in the annotation block, of the column comment") do |value|
-        @options[:position_of_column_comments] = value.to_sym
+        @options[:position_of_column_comment] = value.to_sym
       end
 
       option_parser.on("--with-table-comments",

--- a/spec/lib/annotate_rb/parser_spec.rb
+++ b/spec/lib/annotate_rb/parser_spec.rb
@@ -591,13 +591,13 @@ module AnnotateRb # rubocop:disable Metrics/ModuleLength
       end
     end
 
-    describe "--position-of-column-comments" do
-      let(:option) { "--position-of-column-comments" }
+    describe "--position-of-column-comment" do
+      let(:option) { "--position-of-column-comment" }
       let(:values) { "rightmost_column" }
       let(:args) { [option, values] }
 
       it "sets with_column_comments to true" do
-        expect(result).to include(position_of_column_comments: :rightmost_column)
+        expect(result).to include(position_of_column_comment: :rightmost_column)
       end
     end
 


### PR DESCRIPTION
Now the parser option `position-of-column-comments` does not work well.

The option name `position-of-column-comment` may be correct.
Because it is defined at another place. 
https://github.com/drwl/annotaterb/blob/d9c92140ba13468ec23443b81a99e34818e2544e/lib/annotate_rb/options.rb#L61

Test passed
- [x] `bundle exec rake spec:unit`