### PR TITLE
feat: Add "ignore_multi_database_name" option

### DIFF
--- a/lib/annotate_rb/model_annotator/annotation/annotation_builder.rb
+++ b/lib/annotate_rb/model_annotator/annotation/annotation_builder.rb
@@ -74,6 +74,8 @@ module AnnotateRb
         private
 
         def multi_db_environment?
+          return false if @options[:ignore_multi_database_name]
+
           if defined?(::Rails) && ::Rails.env
             ActiveRecord::Base.configurations.configs_for(env_name: ::Rails.env).size > 1
           else

--- a/lib/annotate_rb/options.rb
+++ b/lib/annotate_rb/options.rb
@@ -76,6 +76,7 @@ module AnnotateRb
       timestamp_columns: ModelAnnotator::ModelWrapper::DEFAULT_TIMESTAMP_COLUMNS,
 
       ignore_columns: nil, # ModelAnnotator
+      ignore_multi_database_name: false, # ModelAnnotator
       ignore_routes: nil, # RouteAnnotator
       ignore_unknown_models: false, # ModelAnnotator
       models: true, # Core


### PR DESCRIPTION
New "modern" Rails apps default to using the "solid trifecta" of solidqueue, cache, and cable. The generator defaults to creating a separate database for each feature meaning all new Rails apps would be multi-database out of the box.

With the introduction of https://github.com/drwl/annotaterb/pull/272/ all Rails apps with the trifecta configured will have "Database: primary" appended to every annotated file even though there's really one database the developer "cares" about as the other gems provide their own models and handling.

This adds an "ignore_multi_database_name" configuration option which disables including the database name even if the app has multiple databases.