### PR TITLE
chore: remove concurrent-ruby version lock from dummy app

### DIFF
--- a/spec/dummyapp/Gemfile
+++ b/spec/dummyapp/Gemfile
@@ -4,11 +4,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.1.0"
 
-# Lock the concurrent-ruby gem to version 1.3.4 to ensure compatibility with
-# the current specs. Reference: rails/rails#54260
-# TODO: Remove the line below when upgrading to Rails 7.1 or higher.
-gem "concurrent-ruby", "1.3.4"
-
 case ENV['DATABASE_ADAPTER'] # This feels so wrong
 when 'mysql2'
   gem 'mysql2', '>= 0.5', '< 1'


### PR DESCRIPTION
Rails 7.0.8 had a bug where Logger wasn't properly required in logger_thread_safe_level.rb. 
This was masked by `concurrent-ruby` 1.3.4 which internally loaded logger, but broke with `concurrent-ruby 1.3.5` when logger dependency was removed.

The dummy app is now on Rails 7.1, which fixes this by properly requiring Logger, making the version lock unnecessary.

refs: rails/rails#54260