### PR TITLE
Load columns from schema to avoid AR ignored/only column configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Annotate model options:
         --without-table-comments     exclude table comments in model annotations
         --classes-default-to-s class Custom classes to be represented with `to_s`, may be used multiple times
         --nested-position            Place annotations directly above nested classes or modules instead of at the top of the file.
+        --load-columns-from-schema   Load columns from schema to avoid ActiveRecord ignored/only column configuration
 
 Annotate routes options:
     Usage: annotaterb routes [options]

--- a/lib/annotate_rb/model_annotator/model_wrapper.rb
+++ b/lib/annotate_rb/model_annotator/model_wrapper.rb
@@ -48,7 +48,12 @@ module AnnotateRb
 
       # Returns the unmodified model columns
       def raw_columns
-        @raw_columns ||= @klass.columns
+        @raw_columns ||= if @options[:load_columns_from_schema]
+          @klass.load_schema
+          @klass.schema_cache.columns_hash(@klass.table_name).values.freeze
+        else
+          @klass.columns
+        end
       end
 
       def primary_key

--- a/lib/annotate_rb/options.rb
+++ b/lib/annotate_rb/options.rb
@@ -51,6 +51,7 @@ module AnnotateRb
       show_indexes: true, # ModelAnnotator
       show_indexes_include: false, # ModelAnnotator
       show_virtual_columns: false, # ModelAnnotator
+      load_columns_from_schema: false, # ModelAnnotator
       simple_indexes: false, # ModelAnnotator
       sort: false, # ModelAnnotator
       timestamp: false, # RouteAnnotator
@@ -119,6 +120,7 @@ module AnnotateRb
       :ignore_model_sub_dir,
       :ignore_unknown_models,
       :include_version,
+      :load_columns_from_schema,
       :show_check_constraints,
       :show_complete_foreign_keys,
       :show_foreign_keys,

--- a/lib/annotate_rb/parser.rb
+++ b/lib/annotate_rb/parser.rb
@@ -274,6 +274,11 @@ module AnnotateRb
         "Place annotations directly above nested classes or modules instead of at the top of the file.") do
         @options[:nested_position] = true
       end
+
+      option_parser.on("--load-columns-from-schema",
+        "Load columns from schema to avoid ActiveRecord ignored/only column configuration") do
+        @options[:load_columns_from_schema] = true
+      end
     end
 
     def add_route_options_to_parser(option_parser)

--- a/spec/dummyapp/app/models/test_default.rb
+++ b/spec/dummyapp/app/models/test_default.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class TestDefault < ApplicationRecord
+  self.ignored_columns = ["ignored_column"]
 end

--- a/spec/dummyapp/db/migrate/20230630123456_create_test_tables.rb
+++ b/spec/dummyapp/db/migrate/20230630123456_create_test_tables.rb
@@ -10,6 +10,7 @@ class CreateTestTables < ActiveRecord::Migration["#{Rails::VERSION::MAJOR}.#{Rai
       t.float :float, default: 12.34
       t.integer :integer, default: 99
       t.string :string, default: 'hello world!'
+      t.string :ignored_column
 
       t.timestamps
     end

--- a/spec/integration/load_columns_from_schema_spec.rb
+++ b/spec/integration/load_columns_from_schema_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "integration_spec_helper"
+
+RSpec.describe "Load columns from schema with ignored columns", type: "aruba" do
+  let(:command_timeout_seconds) { 10 }
+  let(:model_file) { "app/models/test_default.rb" }
+
+  before do
+    copy_dummy_app_into_aruba_working_directory
+    reset_database
+    run_migrations
+  end
+
+  it "does not include ignored columns by default" do
+    run_command_and_stop("bundle exec annotaterb models #{model_file} --force", fail_on_error: true, exit_timeout: command_timeout_seconds)
+
+    annotated_content = read_file(model_file)
+
+    expect(annotated_content).to include("string")
+    expect(annotated_content).not_to include("#  ignored_column")
+  end
+
+  it "includes ignored columns when --load-columns-from-schema is used" do
+    run_command_and_stop("bundle exec annotaterb models #{model_file} --load-columns-from-schema --force", fail_on_error: true, exit_timeout: command_timeout_seconds)
+
+    annotated_content = read_file(model_file)
+
+    expect(annotated_content).to include("string")
+    expect(annotated_content).to include("#  ignored_column")
+  end
+end

--- a/spec/lib/annotate_rb/options_spec.rb
+++ b/spec/lib/annotate_rb/options_spec.rb
@@ -67,6 +67,14 @@ RSpec.describe AnnotateRb::Options do
       end
     end
 
+    context 'when default value of "load_columns_from_schema" is not set' do
+      let(:key) { :load_columns_from_schema }
+
+      it "returns false" do
+        expect(subject[key]).to eq(false)
+      end
+    end
+
     context 'when default value of "show_complete_foreign_keys" is set' do
       let(:key) { :show_complete_foreign_keys }
       let(:options) { {key => true} }

--- a/spec/lib/annotate_rb/parser_spec.rb
+++ b/spec/lib/annotate_rb/parser_spec.rb
@@ -359,6 +359,16 @@ module AnnotateRb # rubocop:disable Metrics/ModuleLength
       end
     end
 
+    %w[--load-columns-from-schema].each do |option|
+      describe option do
+        let(:args) { [option] }
+
+        it "sets load_columns_from_schema to true" do
+          expect(result).to include(load_columns_from_schema: true)
+        end
+      end
+    end
+
     %w[-R --require].each do |option|
       describe option do
         let(:option) { "require" }

--- a/spec/templates/mysql2/test_default.rb
+++ b/spec/templates/mysql2/test_default.rb
@@ -16,4 +16,5 @@
 #  updated_at :datetime         not null
 #
 class TestDefault < ApplicationRecord
+  self.ignored_columns = ["ignored_column"]
 end

--- a/spec/templates/pg/test_default.rb
+++ b/spec/templates/pg/test_default.rb
@@ -16,4 +16,5 @@
 #  updated_at :datetime         not null
 #
 class TestDefault < ApplicationRecord
+  self.ignored_columns = ["ignored_column"]
 end

--- a/spec/templates/sqlite3/test_default.rb
+++ b/spec/templates/sqlite3/test_default.rb
@@ -16,4 +16,5 @@
 #  updated_at :datetime         not null
 #
 class TestDefault < ApplicationRecord
+  self.ignored_columns = ["ignored_column"]
 end


### PR DESCRIPTION
Fixes #286

This PR recreates the Active Record logic for fetching the columns from the schema cache before they are filter based on Active Record's `ignored_columns`/`only_columns` configuration.

- `columns` is defined here: https://github.com/rails/rails/blob/5d4cfc3e73a77bd5ee4fba3ec42e8c3782c9ab02/activerecord/lib/active_record/model_schema.rb#L443-L450
- ...and populated here: https://github.com/rails/rails/blob/5d4cfc3e73a77bd5ee4fba3ec42e8c3782c9ab02/activerecord/lib/active_record/model_schema.rb#L609-L615

