### PR TITLE
Add opt-in support for automatically annotating routes after migration tasks

### DIFF
--- a/lib/annotate_rb/options.rb
+++ b/lib/annotate_rb/options.rb
@@ -82,6 +82,7 @@ module AnnotateRb
       models: true, # Core
       routes: false, # Core
       skip_on_db_migrate: false, # Core
+      auto_annotate_routes_after_migrate: false, # Core
       target_action: :do_annotations, # Core; Possible values: :do_annotations, :remove_annotations
       wrapper: nil, # ModelAnnotator, RouteAnnotator
       wrapper_close: nil, # ModelAnnotator, RouteAnnotator
@@ -148,6 +149,7 @@ module AnnotateRb
       :models,
       :routes,
       :skip_on_db_migrate,
+      :auto_annotate_routes_after_migrate,
       :target_action,
       :wrapper,
       :wrapper_close,

--- a/lib/annotate_rb/runner.rb
+++ b/lib/annotate_rb/runner.rb
@@ -5,10 +5,18 @@ module AnnotateRb
     class << self
       attr_reader :runner
 
-      def run(args)
+      def run_after_migration
+        config_file_options = ConfigLoader.load_config
+        options = Options.from(config_file_options)
+
+        commands = ["models", *(options[:auto_annotate_routes_after_migrate] ? ["routes"] : [])]
+        commands.each { |cmd| run([cmd], config_file_options: config_file_options) }
+      end
+
+      def run(args, config_file_options: nil)
         self.runner = new
 
-        runner.run(args)
+        runner.run(args, config_file_options: config_file_options)
 
         self.runner = nil
       end
@@ -22,14 +30,14 @@ module AnnotateRb
       attr_writer :runner
     end
 
-    def run(args)
+    def run(args, config_file_options: nil)
+      config_file_options ||= ConfigLoader.load_config
       parser = Parser.new(args, {})
 
       parsed_options = parser.parse
       remaining_args = parser.remaining_args
 
       AnnotateRb::ConfigFinder.config_path = parsed_options[:config_path] if parsed_options[:config_path]
-      config_file_options = ConfigLoader.load_config
       options = config_file_options.merge(parsed_options)
 
       @options = Options.from(options, {working_args: remaining_args})

--- a/lib/annotate_rb/tasks/annotate_models_migrate.rake
+++ b/lib/annotate_rb/tasks/annotate_models_migrate.rake
@@ -32,7 +32,7 @@ migration_tasks.each do |task|
     task_name = Rake.application.top_level_tasks.last # The name of the task that was run, e.g. "db:migrate"
 
     Rake::Task[task_name].enhance do
-      ::AnnotateRb::Runner.run(["models"])
+      ::AnnotateRb::Runner.run_after_migration
     end
   end
 end

--- a/spec/lib/annotate_rb/runner_spec.rb
+++ b/spec/lib/annotate_rb/runner_spec.rb
@@ -110,4 +110,42 @@ RSpec.describe AnnotateRb::Runner do
       end
     end
   end
+
+  describe ".run_after_migration" do
+    let(:config_file_options) { {} }
+    let(:options) { instance_double(AnnotateRb::Options) }
+
+    before do
+      allow(AnnotateRb::ConfigLoader).to receive(:load_config).and_return(config_file_options)
+      allow(AnnotateRb::Options).to receive(:from).with(config_file_options).and_return(options)
+    end
+
+    context "when auto_annotate_routes_after_migrate is false" do
+      before do
+        allow(options).to receive(:[]).with(:auto_annotate_routes_after_migrate).and_return(false)
+        allow(AnnotateRb::Runner).to receive(:run)
+      end
+
+      it "runs models annotation only" do
+        described_class.run_after_migration
+
+        expect(AnnotateRb::Runner).to have_received(:run).with(["models"], config_file_options: config_file_options).once
+        expect(AnnotateRb::Runner).not_to have_received(:run).with(["routes"], anything)
+      end
+    end
+
+    context "when auto_annotate_routes_after_migrate is true" do
+      before do
+        allow(options).to receive(:[]).with(:auto_annotate_routes_after_migrate).and_return(true)
+        allow(AnnotateRb::Runner).to receive(:run)
+      end
+
+      it "runs both models and routes annotation" do
+        described_class.run_after_migration
+
+        expect(AnnotateRb::Runner).to have_received(:run).with(["models"], config_file_options: config_file_options).once
+        expect(AnnotateRb::Runner).to have_received(:run).with(["routes"], config_file_options: config_file_options).once
+      end
+    end
+  end
 end

--- a/spec/lib/tasks/annotate_models_migrate_spec.rb
+++ b/spec/lib/tasks/annotate_models_migrate_spec.rb
@@ -27,35 +27,35 @@ RSpec.describe "ActiveRecord migration rake task hooks" do
 
       describe "db:migrate" do
         it "should annotate model files" do
-          expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models"))
+          expect(AnnotateRb::Runner).to receive(:run_after_migration)
           Rake.application.top_level
         end
       end
 
       describe "db:migrate:up" do
         it "should annotate model files" do
-          expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models"))
+          expect(AnnotateRb::Runner).to receive(:run_after_migration)
           Rake.application.top_level
         end
       end
 
       describe "db:migrate:down" do
         it "should annotate model files" do
-          expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models"))
+          expect(AnnotateRb::Runner).to receive(:run_after_migration)
           Rake.application.top_level
         end
       end
 
       describe "db:migrate:reset" do
         it "should annotate model files" do
-          expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models"))
+          expect(AnnotateRb::Runner).to receive(:run_after_migration)
           Rake.application.top_level
         end
       end
 
       describe "db:rollback" do
         it "should annotate model files" do
-          expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models"))
+          expect(AnnotateRb::Runner).to receive(:run_after_migration)
           Rake.application.top_level
         end
       end
@@ -63,7 +63,7 @@ RSpec.describe "ActiveRecord migration rake task hooks" do
       describe "db:migrate:redo" do
         it "should annotate model files after all migration tasks" do
           # Hooked 3 times by db:rollback, db:migrate, and db:migrate:redo tasks
-          expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models")).exactly(3).times
+          expect(AnnotateRb::Runner).to receive(:run_after_migration).exactly(3).times
 
           Rake.application.top_level
         end
@@ -75,42 +75,42 @@ RSpec.describe "ActiveRecord migration rake task hooks" do
 
       describe "db:migrate" do
         it "should not annotate model files" do
-          expect(AnnotateRb::Runner).not_to receive(:run)
+          expect(AnnotateRb::Runner).not_to receive(:run_after_migration)
           Rake.application.top_level
         end
       end
 
       describe "db:migrate:up" do
         it "should not annotate model files" do
-          expect(AnnotateRb::Runner).not_to receive(:run)
+          expect(AnnotateRb::Runner).not_to receive(:run_after_migration)
           Rake.application.top_level
         end
       end
 
       describe "db:migrate:down" do
         it "should not annotate model files" do
-          expect(AnnotateRb::Runner).not_to receive(:run)
+          expect(AnnotateRb::Runner).not_to receive(:run_after_migration)
           Rake.application.top_level
         end
       end
 
       describe "db:migrate:reset" do
         it "should not annotate model files" do
-          expect(AnnotateRb::Runner).not_to receive(:run)
+          expect(AnnotateRb::Runner).not_to receive(:run_after_migration)
           Rake.application.top_level
         end
       end
 
       describe "db:rollback" do
         it "should not annotate model files" do
-          expect(AnnotateRb::Runner).not_to receive(:run)
+          expect(AnnotateRb::Runner).not_to receive(:run_after_migration)
           Rake.application.top_level
         end
       end
 
       describe "db:migrate:redo" do
         it "should not annotate model files" do
-          expect(AnnotateRb::Runner).not_to receive(:run)
+          expect(AnnotateRb::Runner).not_to receive(:run_after_migration)
           Rake.application.top_level
         end
       end
@@ -158,28 +158,28 @@ RSpec.describe "ActiveRecord migration rake task hooks" do
 
       describe "db:migrate:primary" do
         it "should annotate model files" do
-          expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models"))
+          expect(AnnotateRb::Runner).to receive(:run_after_migration)
           Rake.application.top_level
         end
       end
 
       describe "db:migrate:up:primary" do
         it "should annotate model files" do
-          expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models"))
+          expect(AnnotateRb::Runner).to receive(:run_after_migration)
           Rake.application.top_level
         end
       end
 
       describe "db:migrate:down:primary" do
         it "should annotate model files" do
-          expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models"))
+          expect(AnnotateRb::Runner).to receive(:run_after_migration)
           Rake.application.top_level
         end
       end
 
       describe "db:rollback:primary" do
         it "should annotate model files" do
-          expect(AnnotateRb::Runner).to receive(:run).with(a_collection_including("models"))
+          expect(AnnotateRb::Runner).to receive(:run_after_migration)
           Rake.application.top_level
         end
       end
@@ -190,28 +190,28 @@ RSpec.describe "ActiveRecord migration rake task hooks" do
 
       describe "db:migrate:primary" do
         it "should not annotate model files" do
-          expect(AnnotateRb::Runner).not_to receive(:run)
+          expect(AnnotateRb::Runner).not_to receive(:run_after_migration)
           Rake.application.top_level
         end
       end
 
       describe "db:migrate:up:primary" do
         it "should not annotate model files" do
-          expect(AnnotateRb::Runner).not_to receive(:run)
+          expect(AnnotateRb::Runner).not_to receive(:run_after_migration)
           Rake.application.top_level
         end
       end
 
       describe "db:migrate:down:primary" do
         it "should not annotate model files" do
-          expect(AnnotateRb::Runner).not_to receive(:run)
+          expect(AnnotateRb::Runner).not_to receive(:run_after_migration)
           Rake.application.top_level
         end
       end
 
       describe "db:rollback:primary" do
         it "should not annotate model files" do
-          expect(AnnotateRb::Runner).not_to receive(:run)
+          expect(AnnotateRb::Runner).not_to receive(:run_after_migration)
           Rake.application.top_level
         end
       end


### PR DESCRIPTION
Thank you as always for maintaining this project. I really appreciate your continued work.

This change introduces an opt-in feature that allows users to automatically annotate routes after running migration tasks. A new method, `Runner.run_after_migration`, has been added for this purpose, and the `annotate_models_migrate.rake` task has been updated to call this new method instead of invoking `Runner.run(["models"])` directly.

The `auto_annotate_routes_after_migrate` option has been added to the `Options` class, enabling users to turn this behavior on by specifying `auto_annotate_routes_after_migrate: true` in their `.annotaterb.yml`. Corresponding tests have also been added.

Refs: #251