### PR TITLE
fix NoMethodError when using nested_position with fixture files

### DIFF
--- a/lib/annotate_rb/model_annotator/annotated_file/generator.rb
+++ b/lib/annotate_rb/model_annotator/annotated_file/generator.rb
@@ -66,7 +66,7 @@ module AnnotateRb
           # Handle empty files where no classes/modules are found
           return [nil, 0] if parsed.starts.empty?
 
-          return parsed.starts.first unless @options[:nested_position]
+          return parsed.starts.first unless @options[:nested_position] && parsed.respond_to?(:type_map)
 
           class_entries = parsed.starts.select { |name, _line| parsed.type_map[name] == :class }
           class_entries.last || parsed.starts.first

--- a/spec/integration/annotate_collapsed_models_nested_position_spec.rb
+++ b/spec/integration/annotate_collapsed_models_nested_position_spec.rb
@@ -13,8 +13,10 @@ RSpec.describe "Annotate collapsed models with --nested-position", type: "aruba"
 
       expected = read_file(model_template("nested_position_collapsed_test_model.rb"))
 
-      run_command_and_stop("bundle exec annotaterb models --nested-position", fail_on_error: false, exit_timeout: command_timeout_seconds)
+      run_command_and_stop("bundle exec annotaterb models --nested-position", fail_on_error: true, exit_timeout: command_timeout_seconds)
       annotated = read_file(dummyapp_model("collapsed/example/test_model.rb"))
+
+      expect(last_command_started).to be_successfully_executed
       expect(annotated).to eq(expected)
     end
   end


### PR DESCRIPTION
Thanks for maintaining everything 🚀 

## Problem
When the --nested-position option was enabled and annotating fixture files (yml files) with position_in_fixture: "before", a NoMethodError was raised. This occurred because YmlParser does not have the type_map method, which is required by determine_annotation_position to find the most deeply nested class declaration.

The error occurred at:

```rb
parsed.type_map[name] == :class
```

This was not caught in tests because the integration test had fail_on_error: false, allowing the test to pass even when errors occurred.

## Solution
A fallback handling was added to determine_annotation_position for parsers that do not have the type_map method (like YmlParser). When type_map is unavailable, the method falls back to using parsed.starts.first, which is the default behavior for non-nested positioning.

This fix ensures that:

- Fixture files (yml) can be annotated with nested_position: true without errors
- When type_map is unavailable, the behavior gracefully falls back to default positioning
- Ruby files (using CustomParser with type_map) continue to work as expected with nested positioning

## Test Coverage
- Updated the integration test annotate_collapsed_models_nested_position_spec.rb to use fail_on_error: true to catch errors
- Added the be_successfully_executed assertion to explicitly verify that the command completes without errors
- The test now properly validates that nested_position works correctly with fixture files

refs: #270