### PR TITLE
Add to_yard and to_rdoc methods to Annotation classes

### DIFF
--- a/lib/annotate_rb/model_annotator/check_constraint_annotation/annotation.rb
+++ b/lib/annotate_rb/model_annotator/check_constraint_annotation/annotation.rb
@@ -23,6 +23,14 @@ module AnnotateRb
           body.map(&:to_markdown).join("\n")
         end
 
+        def to_rdoc
+          body.map(&:to_rdoc).join("\n")
+        end
+
+        def to_yard
+          body.map(&:to_yard).join("\n")
+        end
+
         def to_default
           body.map(&:to_default).join("\n")
         end

--- a/lib/annotate_rb/model_annotator/foreign_key_annotation/annotation.rb
+++ b/lib/annotate_rb/model_annotator/foreign_key_annotation/annotation.rb
@@ -23,6 +23,14 @@ module AnnotateRb
           body.map(&:to_markdown).join("\n")
         end
 
+        def to_rdoc
+          body.map(&:to_rdoc).join("\n")
+        end
+
+        def to_yard
+          body.map(&:to_yard).join("\n")
+        end
+
         def to_default
           body.map(&:to_default).join("\n")
         end

--- a/lib/annotate_rb/model_annotator/index_annotation/annotation.rb
+++ b/lib/annotate_rb/model_annotator/index_annotation/annotation.rb
@@ -23,6 +23,14 @@ module AnnotateRb
           body.map(&:to_markdown).join("\n")
         end
 
+        def to_rdoc
+          body.map(&:to_rdoc).join("\n")
+        end
+
+        def to_yard
+          body.map(&:to_yard).join("\n")
+        end
+
         def to_default
           body.map(&:to_default).join("\n")
         end

--- a/spec/lib/annotate_rb/model_annotator/check_constraint_annotation/annotation_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/check_constraint_annotation/annotation_builder_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe AnnotateRb::ModelAnnotator::CheckConstraintAnnotation::Annotation
     subject { described_class.new(model, options).build }
     let(:default_format) { subject.to_default }
     let(:markdown_format) { subject.to_markdown }
+    let(:yard_format) { subject.to_yard }
+    let(:rdoc_format) { subject.to_rdoc }
 
     let(:model) do
       instance_double(
@@ -93,6 +95,42 @@ RSpec.describe AnnotateRb::ModelAnnotator::CheckConstraintAnnotation::Annotation
       end
 
       it { expect(default_format).to be_nil }
+    end
+
+    context "using yard format" do
+      let(:expected_result) do
+        <<~RESULT.strip
+          #
+          # Check Constraints
+          #
+          #  alive               (age < 150)
+          #  missing_expression
+          #  multiline_test      (CASE WHEN (age >= 18) THEN (age <= 21) ELSE true END)
+          #  must_be_adult       (age >= 18)
+        RESULT
+      end
+
+      it "annotates the check constraints" do
+        expect(yard_format).to eq(expected_result)
+      end
+    end
+
+    context "using rdoc format" do
+      let(:expected_result) do
+        <<~RESULT.strip
+          #
+          # Check Constraints
+          #
+          #  alive               (age < 150)
+          #  missing_expression
+          #  multiline_test      (CASE WHEN (age >= 18) THEN (age <= 21) ELSE true END)
+          #  must_be_adult       (age >= 18)
+        RESULT
+      end
+
+      it "annotates the check constraints" do
+        expect(rdoc_format).to eq(expected_result)
+      end
     end
   end
 end

--- a/spec/lib/annotate_rb/model_annotator/foreign_key_annotation/annotation_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/foreign_key_annotation/annotation_builder_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe AnnotateRb::ModelAnnotator::ForeignKeyAnnotation::AnnotationBuild
     subject { described_class.new(model, options).build }
     let(:default_format) { subject.to_default }
     let(:markdown_format) { subject.to_markdown }
+    let(:yard_format) { subject.to_yard }
+    let(:rdoc_format) { subject.to_rdoc }
 
     let(:model) do
       klass = begin
@@ -153,6 +155,44 @@ RSpec.describe AnnotateRb::ModelAnnotator::ForeignKeyAnnotation::AnnotationBuild
         end
 
         it { expect(markdown_format).to eq(expected_output) }
+      end
+    end
+
+    describe "#to_yard" do
+      let(:foreign_keys) do
+        [mock_foreign_key("fk_rails_cf2568e89e", "foreign_thing_id", "foreign_things")]
+      end
+
+      let(:expected_output) do
+        <<~OUTPUT.strip
+          #
+          # Foreign Keys
+          #
+          #  fk_rails_cf2568e89e  (foreign_thing_id => foreign_things.id)
+        OUTPUT
+      end
+
+      it "returns annotation in yard format" do
+        expect(yard_format).to eq(expected_output)
+      end
+    end
+
+    describe "#to_rdoc" do
+      let(:foreign_keys) do
+        [mock_foreign_key("fk_rails_cf2568e89e", "foreign_thing_id", "foreign_things")]
+      end
+
+      let(:expected_output) do
+        <<~OUTPUT.strip
+          #
+          # Foreign Keys
+          #
+          #  fk_rails_cf2568e89e  (foreign_thing_id => foreign_things.id)
+        OUTPUT
+      end
+
+      it "returns annotation in rdoc format" do
+        expect(rdoc_format).to eq(expected_output)
       end
     end
   end

--- a/spec/lib/annotate_rb/model_annotator/index_annotation/annotation_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/index_annotation/annotation_builder_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe AnnotateRb::ModelAnnotator::IndexAnnotation::AnnotationBuilder do
     subject { described_class.new(model, options).build }
     let(:default_format) { subject.to_default }
     let(:markdown_format) { subject.to_markdown }
+    let(:yard_format) { subject.to_yard }
+    let(:rdoc_format) { subject.to_rdoc }
 
     let(:model) do
       klass = begin
@@ -161,6 +163,44 @@ RSpec.describe AnnotateRb::ModelAnnotator::IndexAnnotation::AnnotationBuilder do
 
       it "matches the expected result" do
         expect(default_format).to eq(expected_result)
+      end
+    end
+
+    describe "#to_yard" do
+      let(:indexes) do
+        [mock_index("index_rails_02e851e3b7", columns: ["id"])]
+      end
+
+      let(:expected_result) do
+        <<~EOS.strip
+          #
+          # Indexes
+          #
+          #  index_rails_02e851e3b7  (id)
+        EOS
+      end
+
+      it "returns annotation in yard format" do
+        expect(yard_format).to eq(expected_result)
+      end
+    end
+
+    describe "#to_rdoc" do
+      let(:indexes) do
+        [mock_index("index_rails_02e851e3b7", columns: ["id"])]
+      end
+
+      let(:expected_result) do
+        <<~EOS.strip
+          #
+          # Indexes
+          #
+          #  index_rails_02e851e3b7  (id)
+        EOS
+      end
+
+      it "returns annotation in rdoc format" do
+        expect(rdoc_format).to eq(expected_result)
       end
     end
   end


### PR DESCRIPTION
## Summary

  Fix `NoMethodError: undefined method 'to_yard'` when using YARD or RDoc format options.

  Closes #212

  ## Problem

  When running `annotaterb models --format-yard` on a model with indexes, foreign keys, or check constraints:

  NoMethodError: undefined method 'to_yard' for an instance of
  AnnotateRb::ModelAnnotator::IndexAnnotation::Annotation

  ## Solution

  Added `to_yard` and `to_rdoc` methods to:
  - `IndexAnnotation::Annotation`
  - `ForeignKeyAnnotation::Annotation`
  - `CheckConstraintAnnotation::Annotation`

  ## Related

  - Related to #266 (had syntax error and missing `CheckConstraintAnnotation`)

  ## Test

  - [x] Added unit tests for `to_yard` and `to_rdoc` in all three annotation specs