### PR TITLE
Include ignore_multi_database_name in generated config

### DIFF
--- a/lib/annotate_rb/options.rb
+++ b/lib/annotate_rb/options.rb
@@ -144,6 +144,7 @@ module AnnotateRb
       :ignore_columns,
       :ignore_routes,
       :ignore_unknown_models,
+      :ignore_multi_database_name,
       :models,
       :routes,
       :skip_on_db_migrate,


### PR DESCRIPTION
Thanks for always maintaining this project.

## Problem:
The ignore_multi_database_name option was implemented but not included in OTHER_OPTION_KEYS, so it was omitted from .annotaterb.yml files generated by `annotate_rb:install`.

## Solution:
Add ignore_multi_database_name to OTHER_OPTION_KEYS to ensure it is included in generated configuration files.