### PR TITLE
Run CI on CRuby 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.0', '3.1', '3.2', '3.3', '3.4']
+        ruby: ['3.0', '3.1', '3.2', '3.3', '3.4', '4.0']
 
     steps:
       - name: Checkout
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         adapter: [ 'mysql2', 'pg', 'sqlite3' ]
-        ruby: ['3.0', '3.1', '3.2', '3.3', '3.4']
+        ruby: ['3.0', '3.1', '3.2', '3.3', '3.4', '4.0']
 
     steps:
       - name: Checkout
@@ -63,6 +63,10 @@ jobs:
           sudo systemctl start postgresql.service
           sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'root'"
       #          https://github.com/actions/runner-images/issues/7678
+
+      - name: Configure Bundler
+        run: bundle config set path 'vendor/bundle'
+        working-directory: spec/dummyapp
 
       - name: Install dummyapp dependencies (${{ matrix.adapter }})
         run: bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -9,13 +9,15 @@ gem "bigdecimal"
 gem "mutex_m"
 
 group :development, :test do
-  gem "aruba", "~> 2.1.0", require: false
+  gem "aruba", "~> 2.3.0", require: false
   gem "byebug"
   gem "guard-rspec", require: false
 
   gem "rspec"
 
   gem "standard", "~> 1.29.0"
+  gem "benchmark"
+  gem "ostruct"
   gem "terminal-notifier-guard", require: false
 
   platforms :mri, :mingw do


### PR DESCRIPTION
The only non-trivial change is installing gems into `'vendor/bundle'`; I had to add it to fix some CI bundler installation issues related to promoting some gem to stdlib