### PR TITLE
Added command example for applying annotations to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ $ bin/rails g annotate_rb:install
 
 This will copy a rake task into your Rails project's `lib/tasks` directory that will hook into the Rails project rake tasks, automatically running AnnotateRb after database migration rake tasks.
 
+```sh
+$ bin/rails db:migrate
+# ...
+# Annotating models
+# Annotated (1): app/models/task.rb
+```
+
 To skip the automatic annotation that happens after a db task, pass the environment variable `ANNOTATERB_SKIP_ON_DB_TASKS=1` before your command.
 
 ```sh


### PR DESCRIPTION
# Motivation

The existing README includes a command example for skipping annotations, but the steps for applying
annotations are only described in prose, making them easy to overlook.

# Solution

Added a code block showing what happens when you run `bin/rails db:migrate` with AnnotateRb installed,
including sample log output.