### PR TITLE
fix potential ReDoS in route annotator regex

### DIFF
--- a/lib/annotate_rb/route_annotator/base_processor.rb
+++ b/lib/annotate_rb/route_annotator/base_processor.rb
@@ -75,7 +75,7 @@ module AnnotateRb
         header_position = 0
 
         content.split(/\n/, -1).each_with_index do |line, line_number|
-          if mode == :header && line !~ /\s*#/
+          if mode == :header && line !~ /\A\s*#/
             mode = :content
             real_content << line unless line.blank?
           elsif mode == :content

--- a/lib/annotate_rb/route_annotator/helper.rb
+++ b/lib/annotate_rb/route_annotator/helper.rb
@@ -70,7 +70,7 @@ module AnnotateRb
           header_position = 0
 
           content.split(/\n/, -1).each_with_index do |line, line_number|
-            if mode == :header && line !~ /\s*#/
+            if mode == :header && line !~ /\A\s*#/
               mode = :content
               real_content << line unless line.blank?
             elsif mode == :content


### PR DESCRIPTION
Add a `\A` anchor to the `/\s*#/` regex in `strip_annotations` to avoid unnecessary backtracking from an unanchored pattern.

Without the anchor, the regex engine attempts a match at every position in the string. For example, given `"     x"`, it tries position 0, then 1, then 2, and so on. Since each line is already split on newlines, anchoring the pattern to the start of the string does not change the match result, but it does eliminate redundant matching attempts.