### PR TITLE
Exit with non-zero code when database is not accessible

### DIFF
--- a/lib/annotate_rb/model_annotator/annotation_decider.rb
+++ b/lib/annotate_rb/model_annotator/annotation_decider.rb
@@ -33,6 +33,9 @@ module AnnotateRb
             warn "Unable to process #{@file}: #{e.message}"
             warn "\t#{e.backtrace.join("\n\t")}" if @options[:trace]
           end
+        rescue ActiveRecord::ConnectionNotEstablished,
+          ActiveRecord::NoDatabaseError => e
+          abort "AnnotateRb: Database connection error - #{e.message}"
         rescue => e
           warn "Unable to process #{@file}: #{e.message}"
           warn "\t#{e.backtrace.join("\n\t")}" if @options[:trace]

--- a/spec/lib/annotate_rb/model_annotator/annotation_decider_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/annotation_decider_spec.rb
@@ -105,4 +105,46 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationDecider do
     let(:skip_annotation_prefix) { AnnotateRb::ModelAnnotator::AnnotationDecider::SKIP_ANNOTATION_PREFIX }
     it { is_expected.to be false }
   end
+
+  context "when the database is not accessible" do
+    let(:model) { double("User") }
+
+    context "when ActiveRecord::ConnectionNotEstablished is raised" do
+      before do
+        allow(AnnotateRb::ModelAnnotator::ModelClassGetter).to receive(:call)
+          .and_raise(ActiveRecord::ConnectionNotEstablished)
+      end
+
+      it "aborts with an error message instead of silently returning false" do
+        expect { subject }.to raise_error(SystemExit)
+          .and output(/AnnotateRb: Database connection error/).to_stderr
+      end
+    end
+
+    context "when ActiveRecord::NoDatabaseError is raised" do
+      before do
+        allow(AnnotateRb::ModelAnnotator::ModelClassGetter).to receive(:call)
+          .and_raise(ActiveRecord::NoDatabaseError)
+      end
+
+      it "aborts with an error message instead of silently returning false" do
+        expect { subject }.to raise_error(SystemExit)
+          .and output(/AnnotateRb: Database connection error/).to_stderr
+      end
+    end
+  end
+
+  context "when an unexpected error is raised" do
+    let(:model) { double("User") }
+
+    before do
+      allow(AnnotateRb::ModelAnnotator::ModelClassGetter).to receive(:call)
+        .and_raise(RuntimeError, "oops")
+    end
+
+    it "rescues the error and returns false" do
+      expect { subject }.to output(/Unable to process #{file}: oops/).to_stderr
+      expect(subject).to be false
+    end
+  end
 end


### PR DESCRIPTION
## Problem
AnnotationDecider#annotate? has a catch-all `rescue => e` that returns false for any StandardError, including database connection errors. While error messages are printed to stderr, the command still exits with code 0 because the errors are treated as "skip this file" rather than a fatal condition. This is problematic for CI workflows using `--frozen`, where a non-zero exit code is expected on failure.

## Solution
Add a specific rescue for ActiveRecord::ConnectionNotEstablished and ActiveRecord::NoDatabaseError before the catch-all handler. These errors now abort with a clear message and exit code 1, instead of being swallowed by the catch-all and treated as a skippable file-level issue. Other errors (e.g. model syntax errors, LoadError) continue to be rescued and skipped as before.

## Follow-up
exe/annotaterb already has a # TODO: Return exit status comment, and Runner#run does not currently return a meaningful exit status.

As a follow-up, it may make sense to centralize error handling at the Runner or exe/annotaterb level. For example, the entire execution could be wrapped in a single top-level rescue that catches errors, prints a user-friendly message, and exits with a non-zero status. This would allow error handling to be managed in one place, rather than requiring specific exceptions to be handled in lower-level code such as AnnotationDecider. 

[ridgepole](https://github.com/ridgepole/ridgepole/blob/284e604cc26cf9d48d4224618a4fe65b252b0fd8/bin/ridgepole#L299) takes this approach.

However, that would move this change closer to the broader error-handling design, so it has been kept out of scope for this PR.

refs: #240