### PR TITLE
Fix --show-migration option not working on Rails 7.2+.

### DIFF
--- a/lib/annotate_rb/model_annotator/model_wrapper.rb
+++ b/lib/annotate_rb/model_annotator/model_wrapper.rb
@@ -229,7 +229,14 @@ module AnnotateRb
 
         if @options.get_state(cache_key).nil?
           migration_version = begin
-            connection.migration_context.current_version
+            # Rails 7.1+ moved migration_context from ConnectionAdapter to ConnectionPool.
+            # ConnectionAdapter#migration_context was removed in Rails 7.2.
+            # See: https://github.com/rails/rails/pull/51162
+            if connection.pool.respond_to?(:migration_context)
+              connection.pool.migration_context.current_version
+            else
+              connection.migration_context.current_version
+            end
           rescue
             0
           end


### PR DESCRIPTION
## Problem
`ConnectionAdapter#migration_context` was deprecated in Rails 7.1 and removed in Rails 7.2 (rails/rails#51162).
The existing code called `connection.migration_context.current_version`, which raises `NoMethodError` on Rails 7.2+.

## Solution
Use `connection.pool.migration_context` when available (Rails 7.1+), falling back to `connection.migration_context` for older versions.