### PR TITLE
Test additional file patterns with action serializers

### DIFF
--- a/spec/dummyapp/.annotaterb.yml
+++ b/spec/dummyapp/.annotaterb.yml
@@ -1,0 +1,3 @@
+---
+additional_file_patterns:
+  - "app/serializers/%MODEL_NAME%_*_serializer.rb"

--- a/spec/dummyapp/app/serializers/test_default_index_serializer.rb
+++ b/spec/dummyapp/app/serializers/test_default_index_serializer.rb
@@ -15,5 +15,8 @@
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
-class TestDefault < ApplicationRecord
+class TestDefaultIndexSerializer
+  def initialize(test_default)
+    @test_default = test_default
+  end
 end

--- a/spec/dummyapp/app/serializers/test_default_show_serializer.rb
+++ b/spec/dummyapp/app/serializers/test_default_show_serializer.rb
@@ -15,5 +15,8 @@
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
-class TestDefault < ApplicationRecord
+class TestDefaultShowSerializer
+  def initialize(test_default)
+    @test_default = test_default
+  end
 end


### PR DESCRIPTION
## Summary
This PR demonstrates that action-specific serializers can be annotated with the existing `additional_file_patterns` option.

For example, serializers named like this:

```txt
app/serializers/test_default_index_serializer.rb
app/serializers/test_default_show_serializer.rb
```

can be picked up with:

```yml
additional_file_patterns:
  - "app/serializers/%MODEL_NAME%_*_serializer.rb"
```

This allows serializers such as TestDefaultIndexSerializer and TestDefaultShowSerializer to receive the schema annotation for TestDefault.

This is a reference PR to demonstrate that action-specific serializers can be annotated with the existing `additional_file_patterns` option.