### PR TITLE
Respect `--config-path` during config loading

### DIFF
--- a/lib/annotate_rb/runner.rb
+++ b/lib/annotate_rb/runner.rb
@@ -31,13 +31,13 @@ module AnnotateRb
     end
 
     def run(args, config_file_options: nil)
-      config_file_options ||= ConfigLoader.load_config
       parser = Parser.new(args, {})
 
       parsed_options = parser.parse
       remaining_args = parser.remaining_args
 
       AnnotateRb::ConfigFinder.config_path = parsed_options[:config_path] if parsed_options[:config_path]
+      config_file_options = ConfigLoader.load_config if config_file_options.nil?
       options = config_file_options.merge(parsed_options)
 
       @options = Options.from(options, {working_args: remaining_args})

--- a/spec/lib/annotate_rb/runner_spec.rb
+++ b/spec/lib/annotate_rb/runner_spec.rb
@@ -69,6 +69,30 @@ RSpec.describe AnnotateRb::Runner do
     end
   end
 
+  describe "custom config path", :isolated_environment do
+    let(:command_double) { instance_double(AnnotateRb::Commands::AnnotateModels) }
+
+    before do
+      File.write(".annotaterb.yml", "show_indexes: false\n")
+      File.write("custom_annotaterb.yml", "show_indexes: true\n")
+
+      allow(AnnotateRb::Commands::AnnotateModels).to receive(:new).and_return(command_double)
+      allow(command_double).to receive(:call)
+    end
+
+    after do
+      AnnotateRb::ConfigFinder.config_path = nil
+    end
+
+    it "loads the config file specified by --config-path" do
+      runner.run(["models", "--config-path", "custom_annotaterb.yml"])
+
+      expect(command_double).to have_received(:call) do |options|
+        expect(options[:show_indexes]).to be(true)
+      end
+    end
+  end
+
   describe "Annotating routes" do
     let(:args) { ["routes"] }
     let(:command_double) { instance_double(AnnotateRb::Commands::AnnotateRoutes) }


### PR DESCRIPTION
## Problem
#301 added support for loading a config file from a custom path via `--config-path`. However, #293 changed `Runner#run` so that the config is loaded before CLI arguments are parsed.

As a result, `--config-path` was only parsed after the config had already been loaded, meaning the custom path was not used when deciding which config file to read.

## Solution
Parse CLI arguments before loading the config in `Runner#run`.

This ensures that the value passed to `--config-path` is applied to `ConfigFinder.config_path` before `ConfigLoader.load_config` is called.