### PR TITLE
Preserve indentation when re-running annotaterb on nested-position annotations.

### DIFF
--- a/lib/annotate_rb/model_annotator/annotated_file/updater.rb
+++ b/lib/annotate_rb/model_annotator/annotated_file/updater.rb
@@ -18,12 +18,25 @@ module AnnotateRb
         def update
           return "" if !@parsed_file.has_annotations?
 
-          new_annotation = wrapped_content(@new_annotations)
+          new_annotation = indent(wrapped_content(@new_annotations), existing_indentation)
 
           _content = @file_content.sub(@parsed_file.annotations) { new_annotation }
         end
 
         private
+
+        # Returns the leading whitespace of the existing annotation block so
+        # nested-position annotations keep their indentation across re-runs.
+        def existing_indentation
+          first_line = @parsed_file.annotations.lines.first
+          first_line&.match(/\A([ \t]*)/)&.[](1) || ""
+        end
+
+        def indent(content, indentation)
+          return content if indentation.empty?
+
+          content.lines.map { |line| (line == "\n") ? line : "#{indentation}#{line}" }.join
+        end
 
         def wrapped_content(content)
           wrapper_open = if @options[:wrapper_open]

--- a/lib/annotate_rb/model_annotator/annotation_diff_generator.rb
+++ b/lib/annotate_rb/model_annotator/annotation_diff_generator.rb
@@ -4,14 +4,17 @@ module AnnotateRb
   module ModelAnnotator
     # Compares the current file content and new annotation block and generates the column annotation differences
     class AnnotationDiffGenerator
-      HEADER_PATTERN = /(^# Table name:.*?\n(#.*\r?\n)*\r?)/
+      # Leading whitespace is tolerated so that annotations placed inside a
+      # nested module/class (i.e. with --nested-position, or hand-aligned)
+      # still match.
+      HEADER_PATTERN = /(^[ \t]*# Table name:.*?\n([ \t]*#.*\r?\n)*\r?)/
       # Example matches:
       #   - "#  id              :uuid             not null, primary key"
       #   - "#  title(length 255) :string          not null"
       #   - "#  status(a/b/c)    :string           not null"
       #   - "#  created_at       :datetime         not null"
       #   - "#  updated_at       :datetime         not null"
-      COLUMN_PATTERN = /^#[\t ]+[[\p{L}\p{N}_]*.`\[\]():]+(?:\(.*?\))?[\t ]+.+$/
+      COLUMN_PATTERN = /^[ \t]*#[\t ]+[[\p{L}\p{N}_]*.`\[\]():]+(?:\(.*?\))?[\t ]+.+$/
       class << self
         def call(file_content, annotation_block)
           new(file_content, annotation_block).generate
@@ -30,14 +33,16 @@ module AnnotateRb
         current_annotations = @file_content.match(HEADER_PATTERN).to_s
         new_annotations = @annotation_block.match(HEADER_PATTERN).to_s
 
+        # Strip leading whitespace from each scanned column so that an
+        # indented existing block compares equal to a flush-left new block.
         current_annotation_columns = if current_annotations.present?
-          current_annotations.scan(COLUMN_PATTERN)
+          current_annotations.scan(COLUMN_PATTERN).map(&:lstrip)
         else
           []
         end
 
         new_annotation_columns = if new_annotations.present?
-          new_annotations.scan(COLUMN_PATTERN)
+          new_annotations.scan(COLUMN_PATTERN).map(&:lstrip)
         else
           []
         end

--- a/spec/lib/annotate_rb/model_annotator/annotated_file/updater_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/annotated_file/updater_spec.rb
@@ -343,5 +343,69 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotatedFile::Updater do
         is_expected.to eq(expected_content)
       end
     end
+
+    context "when existing annotation is indented inside a nested module" do
+      let(:file_content) do
+        <<~FILE
+          # frozen_string_literal: true
+
+          module Blog
+            class Post
+              # == Schema Information
+              #
+              # Table name: blog_comments
+              #
+              #  id      :bigint           not null, primary key
+              #  body    :text             not null
+              #  post_id :bigint           not null
+              #
+              class Comment < ApplicationRecord
+              end
+            end
+          end
+        FILE
+      end
+      let(:new_annotations) do
+        <<~ANNOTATIONS
+          # == Schema Information
+          #
+          # Table name: blog_comments
+          #
+          #  id          :bigint           not null, primary key
+          #  body        :text             not null
+          #  post_id     :bigint           not null
+          #  approved_at :datetime
+          #
+        ANNOTATIONS
+      end
+
+      let(:options) { AnnotateRb::Options.new({position_in_class: "before"}) }
+
+      let(:expected_content) do
+        <<~CONTENT
+          # frozen_string_literal: true
+
+          module Blog
+            class Post
+              # == Schema Information
+              #
+              # Table name: blog_comments
+              #
+              #  id          :bigint           not null, primary key
+              #  body        :text             not null
+              #  post_id     :bigint           not null
+              #  approved_at :datetime
+              #
+              class Comment < ApplicationRecord
+              end
+            end
+          end
+        CONTENT
+      end
+
+      it "preserves the leading indentation of every annotation line" do
+        is_expected.to eq(expected_content)
+      end
+    end
   end
 end

--- a/spec/lib/annotate_rb/model_annotator/annotation_diff_generator_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/annotation_diff_generator_spec.rb
@@ -292,5 +292,63 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotationDiffGenerator do
         expect(subject.changed?).to eq(true)
       end
     end
+
+    context "when existing annotations are indented (nested-position style)" do
+      let(:file_content) do
+        <<~FILE
+          # frozen_string_literal: true
+
+          module Blog
+            class Post
+              # == Schema Information
+              #
+              # Table name: blog_comments
+              #
+              #  id      :bigint           not null, primary key
+              #  body    :text             not null
+              #  post_id :bigint           not null
+              #
+              class Comment < ApplicationRecord
+              end
+            end
+          end
+        FILE
+      end
+      let(:annotation_block) do
+        <<~ANNOTATION
+          # == Schema Information
+          #
+          # Table name: blog_comments
+          #
+          #  id      :bigint           not null, primary key
+          #  body    :text             not null
+          #  post_id :bigint           not null
+          #
+        ANNOTATION
+      end
+
+      let(:current_columns) do
+        [
+          "# Table name: blog_comments",
+          "#  id      :bigint           not null, primary key",
+          "#  body    :text             not null",
+          "#  post_id :bigint           not null"
+        ]
+      end
+      let(:new_columns) do
+        [
+          "# Table name: blog_comments",
+          "#  id      :bigint           not null, primary key",
+          "#  body    :text             not null",
+          "#  post_id :bigint           not null"
+        ]
+      end
+
+      it "matches the indented annotation against the new annotation block" do
+        test_columns_match_expected
+
+        expect(subject.changed?).to eq(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #332.

When a schema annotation is placed inside a nested module/class (e.g. via `--nested-position`, or hand-aligned to match the surrounding indentation), re-running annotaterb stripped the indentation off every line of the block.

On top of that, the re-run happened even when the schema had not changed, because the diff generator never recognised an indented block as "the same" as the freshly generated, flush-left one.

This PR fixes both halves of that problem so that nested-position annotations are stable across re-runs.