### PR TITLE
Fix annotation placement in nested files and around trailing user comments

### DIFF
--- a/lib/annotate_rb/model_annotator/annotated_file/generator.rb
+++ b/lib/annotate_rb/model_annotator/annotated_file/generator.rb
@@ -59,17 +59,8 @@ module AnnotateRb
           content_with_annotations_written_before.join
         end
 
-        # Determines where to place the annotation based on the nested_position option.
-        # When nested_position is enabled, finds the most deeply nested class declaration
-        # to place annotations directly above nested classes instead of at the file top.
         def determine_annotation_position(parsed)
-          # Handle empty files where no classes/modules are found
-          return [nil, 0] if parsed.starts.empty?
-
-          return parsed.starts.first unless @options[:nested_position] && parsed.respond_to?(:type_map)
-
-          class_entries = parsed.starts.select { |name, _line| parsed.type_map[name] == :class }
-          class_entries.last || parsed.starts.first
+          FileParser::AnnotationTarget.find(parsed, @options) || [nil, 0]
         end
 
         # Formats annotations with appropriate indentation for consistent code structure.

--- a/lib/annotate_rb/model_annotator/file_parser.rb
+++ b/lib/annotate_rb/model_annotator/file_parser.rb
@@ -4,6 +4,7 @@ module AnnotateRb
   module ModelAnnotator
     module FileParser
       autoload :AnnotationFinder, "annotate_rb/model_annotator/file_parser/annotation_finder"
+      autoload :AnnotationTarget, "annotate_rb/model_annotator/file_parser/annotation_target"
       autoload :CustomParser, "annotate_rb/model_annotator/file_parser/custom_parser"
       autoload :ParsedFile, "annotate_rb/model_annotator/file_parser/parsed_file"
       autoload :ParsedFileResult, "annotate_rb/model_annotator/file_parser/parsed_file_result"

--- a/lib/annotate_rb/model_annotator/file_parser/annotation_finder.rb
+++ b/lib/annotate_rb/model_annotator/file_parser/annotation_finder.rb
@@ -8,6 +8,20 @@ module AnnotateRb
         COMPAT_PREFIX_MD = "## Schema Info"
         DEFAULT_ANNOTATION_ENDING = "#"
 
+        SCHEMA_HEADER_PREFIXES = [
+          COMPAT_PREFIX,
+          COMPAT_PREFIX_MD,
+          "Table name:",
+          "Database name:",
+          "Schema version:"
+        ].freeze
+
+        SCHEMA_HEADER_EXACT = [
+          IndexAnnotation::Annotation::HEADER_TEXT,
+          ForeignKeyAnnotation::Annotation::HEADER_TEXT,
+          CheckConstraintAnnotation::Annotation::HEADER_TEXT
+        ].freeze
+
         class MalformedAnnotation < StandardError; end
 
         class NoAnnotationFound < StandardError; end
@@ -70,10 +84,7 @@ module AnnotateRb
               end
             end
           else
-            # Walk back until we find the end of the annotation comment block
-            while ending > start && comments[ending].first != DEFAULT_ANNOTATION_ENDING
-              ending -= 1
-            end
+            ending = walk_forward_through_schema(comments, start, ending)
           end
 
           # We want .last because we want the line indexes
@@ -94,6 +105,30 @@ module AnnotateRb
         # Returns true if annotations are detected in the file content
         def annotated?
           @annotation_start && @annotation_end
+        end
+
+        private
+
+        def walk_forward_through_schema(comments, start, block_end)
+          ending = start
+          while ending < block_end
+            break unless schema_like?(comments[ending + 1].first)
+            ending += 1
+          end
+          ending
+        end
+
+        # Tabular rows have ≥2 leading spaces after `#`; prose has at most one.
+        def schema_like?(comment)
+          return true if comment == DEFAULT_ANNOTATION_ENDING
+
+          text = comment.sub(/\A#\s?/, "")
+          return false if text.empty?
+
+          return true if SCHEMA_HEADER_PREFIXES.any? { |p| text.start_with?(p) }
+          return true if SCHEMA_HEADER_EXACT.include?(text)
+
+          comment.match?(/\A#\s{2,}\S/)
         end
       end
     end

--- a/lib/annotate_rb/model_annotator/file_parser/annotation_target.rb
+++ b/lib/annotate_rb/model_annotator/file_parser/annotation_target.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module AnnotateRb
+  module ModelAnnotator
+    module FileParser
+      module AnnotationTarget
+        SKIP_NAMES = %w[require require_relative load].freeze
+
+        def self.find(parser, options)
+          starts = parser.starts.reject { |entry| SKIP_NAMES.include?(entry.first) }
+          return nil if starts.empty?
+
+          return starts.first unless options[:nested_position] && parser.respond_to?(:type_map)
+
+          class_entries = starts
+            .select { |name, _line| parser.type_map[name] == :class }
+            .uniq { |name, _line| name }
+
+          class_entries.last || starts.first
+        end
+      end
+    end
+  end
+end

--- a/lib/annotate_rb/model_annotator/file_parser/parsed_file.rb
+++ b/lib/annotate_rb/model_annotator/file_parser/parsed_file.rb
@@ -64,10 +64,8 @@ module AnnotateRb
           annotation_position = nil
 
           if has_annotations
-            const_declaration = @file_parser.starts.first
-
-            # If the file does not have any class or module declaration then const_declaration can be nil
-            _const, line_number = const_declaration
+            target = AnnotationTarget.find(@file_parser, @options)
+            _const, line_number = target if target
 
             if line_number
               annotation_position = if @finder.annotation_start < line_number

--- a/spec/lib/annotate_rb/model_annotator/file_parser/annotation_finder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/file_parser/annotation_finder_spec.rb
@@ -338,6 +338,113 @@ RSpec.describe AnnotateRb::ModelAnnotator::FileParser::AnnotationFinder do
       include_examples "finds and extracts the annotation"
     end
 
+    context "with a multi-paragraph user documentation comment between annotation and class" do
+      let(:content) do
+        <<~FILE
+          # frozen_string_literal: true
+
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id                     :bigint           not null, primary key
+          #
+          # First paragraph of user documentation.
+          #
+          # Second paragraph of user documentation.
+          class User < ApplicationRecord
+          end
+        FILE
+      end
+      let(:annotation_start) { 2 }
+      let(:annotation_end) { 7 }
+      let(:annotation) do
+        <<~ANNOTATION
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id                     :bigint           not null, primary key
+          #
+        ANNOTATION
+      end
+
+      include_examples "finds and extracts the annotation"
+    end
+
+    context "with a user documentation comment containing a tabular-looking row" do
+      let(:content) do
+        <<~FILE
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id                     :bigint           not null, primary key
+          #
+          # Indexes
+          #
+          #  index_users_on_email  (email) UNIQUE
+          #
+          # Below is a freeform note from the developer.
+          class User < ApplicationRecord
+          end
+        FILE
+      end
+      let(:annotation_start) { 0 }
+      let(:annotation_end) { 9 }
+      let(:annotation) do
+        <<~ANNOTATION
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id                     :bigint           not null, primary key
+          #
+          # Indexes
+          #
+          #  index_users_on_email  (email) UNIQUE
+          #
+        ANNOTATION
+      end
+
+      include_examples "finds and extracts the annotation"
+    end
+
+    context "with an annotation that ends without the canonical trailing # separator" do
+      let(:content) do
+        <<~FILE
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id                     :bigint           not null, primary key
+          #
+          # Foreign Keys
+          #
+          #  fk_rails_...  (parent_id => parents.id)
+          class User < ApplicationRecord
+          end
+        FILE
+      end
+      let(:annotation_start) { 0 }
+      let(:annotation_end) { 8 }
+      let(:annotation) do
+        <<~ANNOTATION
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id                     :bigint           not null, primary key
+          #
+          # Foreign Keys
+          #
+          #  fk_rails_...  (parent_id => parents.id)
+        ANNOTATION
+      end
+
+      include_examples "finds and extracts the annotation"
+    end
+
     context "with a yml file without annotations" do
       subject { described_class.new(content, wrapper_open, wrapper_close, yml_parser) }
 

--- a/spec/lib/annotate_rb/model_annotator/file_parser/annotation_target_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/file_parser/annotation_target_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+RSpec.describe AnnotateRb::ModelAnnotator::FileParser::AnnotationTarget do
+  describe ".find" do
+    subject { described_class.find(parser, options) }
+
+    let(:parser) { AnnotateRb::ModelAnnotator::FileParser::CustomParser.parse(content) }
+    let(:options) { AnnotateRb::Options.new({nested_position: nested_position}) }
+    let(:nested_position) { false }
+
+    context "with an empty file" do
+      let(:content) { "" }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "with a single class" do
+      let(:content) do
+        <<~FILE
+          class Sample < ApplicationRecord
+          end
+        FILE
+      end
+
+      it "returns the class start" do
+        const, line = subject
+        expect(const).to eq("Sample")
+        expect(line).to eq(0)
+      end
+    end
+
+    context "with a leading require" do
+      let(:content) do
+        <<~FILE
+          require 'rails_helper'
+
+          RSpec.describe Sample do
+          end
+        FILE
+      end
+
+      it "skips require and returns the first non-require start" do
+        _const, line = subject
+        expect(line).to eq(2)
+      end
+    end
+
+    context "with a leading require_relative" do
+      let(:content) do
+        <<~FILE
+          require_relative '../helper'
+
+          class Sample < ApplicationRecord
+          end
+        FILE
+      end
+
+      it "skips require_relative" do
+        const, line = subject
+        expect(const).to eq("Sample")
+        expect(line).to eq(2)
+      end
+    end
+
+    context "with multiple require lines" do
+      let(:content) do
+        <<~FILE
+          require 'rails_helper'
+          require 'support/helper'
+          require_relative '../local'
+
+          RSpec.describe Sample do
+          end
+        FILE
+      end
+
+      it "skips all leading require directives" do
+        _const, line = subject
+        expect(line).to eq(4)
+      end
+    end
+
+    context "with nested_position and a class referenced inside its own method body" do
+      let(:nested_position) { true }
+      let(:content) do
+        <<~FILE
+          class Sample < ApplicationRecord
+            def call
+              Sample.new
+              Sample::Helper.run
+            end
+          end
+        FILE
+      end
+
+      it "returns the class declaration line, not a later const reference" do
+        const, line = subject
+        expect(const).to eq("Sample")
+        expect(line).to eq(0)
+      end
+    end
+
+    context "with nested_position and a parent class referenced from an include path" do
+      let(:nested_position) { true }
+      let(:content) do
+        <<~FILE
+          module Alpha
+            class Beta
+              module Gamma
+                class Delta < ApplicationRecord
+                  include Alpha::Beta::Gamma::SomeMixin
+                end
+              end
+            end
+          end
+        FILE
+      end
+
+      it "returns the deepest class, not a re-reference inside the body" do
+        const, line = subject
+        expect(const).to eq("Delta")
+        expect(line).to eq(3)
+      end
+    end
+
+    context "with nested_position and only modules" do
+      let(:nested_position) { true }
+      let(:content) do
+        <<~FILE
+          module Alpha
+            module Beta
+            end
+          end
+        FILE
+      end
+
+      it "falls back to the first non-require start when no class is found" do
+        const, line = subject
+        expect(const).to eq("Alpha")
+        expect(line).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Two real-world layouts make annotaterb misplace or corrupt the schema annotation.

### 1. The end of an existing annotation gets mis-detected

`AnnotationFinder` walks backward looking for the first `#` separator. With a multi-paragraph user doc placed after the schema, the walk stops *inside* the user's doc:

```ruby
# == Schema Information
# Table name: users
# ...
#                                  # ← actual end of schema
# First paragraph of user doc.
#                                  # ← walk-back stops HERE (wrong)
# Second paragraph of user doc.
class User < ApplicationRecord
```

The first paragraph and the inner `#` are absorbed into the detected annotation range and silently lost when the annotation is rewritten.

The same logic fails when the annotation lacks its trailing `#` separator (e.g. manually trimmed): the walk stops at a section-internal `#`, and the trailing content row escapes the detected range — duplicating on the next run.

### 2. The annotation target line is wrong in nested files

`Generator#determine_annotation_position` previously used `parsed.starts.first` (no class case) and `parsed.starts.select { |name, _| type_map[name] == :class }.last` (class case). Both fail on common shapes:

```ruby
# spec file: parsed.starts.first picks `require`,
# so the annotation lands above the require line:
# == Schema Information       # ← wrong: should be just above RSpec.describe
# ...
require 'rails_helper'

RSpec.describe Sample do
end
```

```ruby
# self-reference inside the method body: `.last` picks
# the body reference, so the annotation lands inside the method:
class Sample < ApplicationRecord
  def call
    # == Schema Information    # ← wrong: should be above `class Sample`
    # ...
    Sample::Helper.run
  end
end
```

## Solution

Two small post-processors over `CustomParser`'s raw output.

**`walk_forward_through_schema`** (in `AnnotationFinder`, replaces the walk-back). Advances from the schema header while every successor matches `schema_like?` — a header prefix, an exact header (Indexes / Foreign Keys / Check Constraints), a tabular row (`#` + 2+ leading spaces), or a `#` separator. Stops at the last schema-like comment.

**`FileParser::AnnotationTarget.find`** (new). Skips `require` / `require_relative` / `load` and de-duplicates class entries by name so each class only contributes its declaration line. `Generator` and `ParsedFile` both go through it.