### PR TITLE
Fix annotation placement above inner class declarations under `nested_position`

### DIFF
--- a/lib/annotate_rb/model_annotator/annotated_file/generator.rb
+++ b/lib/annotate_rb/model_annotator/annotated_file/generator.rb
@@ -5,7 +5,7 @@ module AnnotateRb
     module AnnotatedFile
       # Generates the file with fresh annotations
       class Generator
-        def initialize(file_content, new_annotations, annotation_position, parser_klass, parsed_file, options)
+        def initialize(file_content, new_annotations, annotation_position, parser_klass, parsed_file, options, model_class_name: nil)
           @annotation_position = annotation_position
           @options = options
 
@@ -16,6 +16,7 @@ module AnnotateRb
 
           @parser = parser_klass
           @parsed_file = parsed_file
+          @model_class_name = model_class_name
         end
 
         # @return [String] Returns the annotated file content to be written back to a file
@@ -60,7 +61,7 @@ module AnnotateRb
         end
 
         def determine_annotation_position(parsed)
-          FileParser::AnnotationTarget.find(parsed, @options) || [nil, 0]
+          FileParser::AnnotationTarget.find(parsed, @options, model_class_name: @model_class_name) || [nil, 0]
         end
 
         # Formats annotations with appropriate indentation for consistent code structure.

--- a/lib/annotate_rb/model_annotator/file_parser/annotation_target.rb
+++ b/lib/annotate_rb/model_annotator/file_parser/annotation_target.rb
@@ -3,14 +3,21 @@
 module AnnotateRb
   module ModelAnnotator
     module FileParser
+      # When `model_class_name` is given, matches that class declaration directly
+      # so inner classes inside the model body cannot be mistaken for the target.
       module AnnotationTarget
         SKIP_NAMES = %w[require require_relative load].freeze
 
-        def self.find(parser, options)
+        def self.find(parser, options, model_class_name: nil)
           starts = parser.starts.reject { |entry| SKIP_NAMES.include?(entry.first) }
           return nil if starts.empty?
 
           return starts.first unless options[:nested_position] && parser.respond_to?(:type_map)
+
+          if model_class_name && parser.type_map[model_class_name] == :class
+            match = starts.find { |name, _line| name == model_class_name }
+            return match if match
+          end
 
           class_entries = starts
             .select { |name, _line| parser.type_map[name] == :class }

--- a/lib/annotate_rb/model_annotator/file_parser/parsed_file.rb
+++ b/lib/annotate_rb/model_annotator/file_parser/parsed_file.rb
@@ -6,12 +6,13 @@ module AnnotateRb
       class ParsedFile
         SKIP_ANNOTATION_STRING = "# -*- SkipSchemaAnnotations"
 
-        def initialize(file_content, new_annotations, parser_klass, options)
+        def initialize(file_content, new_annotations, parser_klass, options, model_class_name: nil)
           @file_content = file_content
           @file_lines = @file_content.lines
           @new_annotations = new_annotations
           @parser_klass = parser_klass
           @options = options
+          @model_class_name = model_class_name
         end
 
         def parse
@@ -64,7 +65,7 @@ module AnnotateRb
           annotation_position = nil
 
           if has_annotations
-            target = AnnotationTarget.find(@file_parser, @options)
+            target = AnnotationTarget.find(@file_parser, @options, model_class_name: @model_class_name)
             _const, line_number = target if target
 
             if line_number

--- a/lib/annotate_rb/model_annotator/project_annotator.rb
+++ b/lib/annotate_rb/model_annotator/project_annotator.rb
@@ -42,13 +42,14 @@ module AnnotateRb
         klass.reset_column_information
         annotation = Annotation::AnnotationBuilder.new(klass, @options).build
         model_name = klass.name.underscore
+        model_class_name = klass.name.demodulize
 
         # In multi-database configurations, it is possible for different models to have the same table name but live
         #   in different databases. Here we are opting to use the table name to find related files only when the model
         #   is using the primary connection.
         table_name = klass.table_name if klass.connection_specification_name == ActiveRecord::Base.name
 
-        model_instruction = SingleFileAnnotatorInstruction.new(file, annotation, :position_in_class, @options)
+        model_instruction = SingleFileAnnotatorInstruction.new(file, annotation, :position_in_class, @options, model_class_name: model_class_name)
         instructions << model_instruction
 
         related_files = RelatedFilesListBuilder.new(file, model_name, table_name, @options).build

--- a/lib/annotate_rb/model_annotator/single_file_annotator.rb
+++ b/lib/annotate_rb/model_annotator/single_file_annotator.rb
@@ -5,7 +5,7 @@ module AnnotateRb
     class SingleFileAnnotator
       class << self
         def call_with_instructions(instruction)
-          call(instruction.file, instruction.annotation, instruction.position, instruction.options)
+          call(instruction.file, instruction.annotation, instruction.position, instruction.options, model_class_name: instruction.model_class_name)
         end
 
         # Add a schema block to a file. If the file already contains
@@ -21,14 +21,14 @@ module AnnotateRb
         #  :position_in_*<Symbol>:: where to place the annotated section in fixture or model file,
         #                           :before, :top, :after or :bottom. Default is :before.
         #
-        def call(file_name, annotation, annotation_position, options)
+        def call(file_name, annotation, annotation_position, options, model_class_name: nil)
           return false unless File.exist?(file_name)
           old_content = File.read(file_name)
 
           parser_klass = FileToParserMapper.map(file_name)
 
           begin
-            parsed_file = FileParser::ParsedFile.new(old_content, annotation, parser_klass, options).parse
+            parsed_file = FileParser::ParsedFile.new(old_content, annotation, parser_klass, options, model_class_name: model_class_name).parse
           rescue FileParser::AnnotationFinder::MalformedAnnotation => e
             warn "Unable to process #{file_name}: #{e.message}"
             warn "\t" + e.backtrace.join("\n\t") if @options[:trace]
@@ -41,9 +41,9 @@ module AnnotateRb
           abort "AnnotateRb error. #{file_name} needs to be updated, but annotaterb was run with `--frozen`." if options[:frozen]
 
           updated_file_content = if !parsed_file.has_annotations?
-            AnnotatedFile::Generator.new(old_content, annotation, annotation_position, parser_klass, parsed_file, options).generate
+            AnnotatedFile::Generator.new(old_content, annotation, annotation_position, parser_klass, parsed_file, options, model_class_name: model_class_name).generate
           elsif options[:force]
-            AnnotatedFile::Generator.new(old_content, annotation, annotation_position, parser_klass, parsed_file, options).generate
+            AnnotatedFile::Generator.new(old_content, annotation, annotation_position, parser_klass, parsed_file, options, model_class_name: model_class_name).generate
           else
             AnnotatedFile::Updater.new(old_content, annotation, annotation_position, parsed_file, options).update
           end

--- a/lib/annotate_rb/model_annotator/single_file_annotator_instruction.rb
+++ b/lib/annotate_rb/model_annotator/single_file_annotator_instruction.rb
@@ -4,14 +4,15 @@ module AnnotateRb
   module ModelAnnotator
     # A plain old Ruby object (PORO) that contains all necessary information for SingleFileAnnotator
     class SingleFileAnnotatorInstruction
-      def initialize(file, annotation, position, options)
+      def initialize(file, annotation, position, options, model_class_name: nil)
         @file = file # Path to file
         @annotation = annotation # Annotation string
         @position = position # Position in the file where to write the annotation to
         @options = options
+        @model_class_name = model_class_name # Short class name; set for the model file itself, nil for related files
       end
 
-      attr_reader :file, :annotation, :position, :options
+      attr_reader :file, :annotation, :position, :options, :model_class_name
     end
   end
 end

--- a/spec/lib/annotate_rb/model_annotator/annotating_a_file_with_comments_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/annotating_a_file_with_comments_spec.rb
@@ -6,12 +6,13 @@ RSpec.describe "Annotating a file with comments" do
 
   shared_examples "annotates the file" do
     it "writes the expected annotations to the file" do
-      AnnotateRb::ModelAnnotator::SingleFileAnnotator.call(@model_file_name, schema_info, :position_in_class, options)
+      AnnotateRb::ModelAnnotator::SingleFileAnnotator.call(@model_file_name, schema_info, :position_in_class, options, model_class_name: model_class_name)
       expect(File.read(@model_file_name)).to eq(expected_file_content)
     end
   end
 
   let(:options) { AnnotateRb::Options.from({}) }
+  let(:model_class_name) { nil }
   let(:schema_info) do
     <<~SCHEMA
       # == Schema Information
@@ -1739,6 +1740,63 @@ RSpec.describe "Annotating a file with comments" do
           #
 
           class User < ApplicationRecord
+          end
+        FILE
+      end
+
+      include_examples "annotates the file"
+    end
+  end
+
+  context "when annotating a model with inner class declarations and nested_position" do
+    let(:options) do
+      AnnotateRb::Options.from({nested_position: true, force: true})
+    end
+
+    context "with an inner error class declared inside the body" do
+      let(:model_class_name) { "User" }
+
+      let(:starting_file_content) do
+        <<~FILE
+          # frozen_string_literal: true
+
+          module Outer
+            module Inner
+              class User < ApplicationRecord
+                include SomeMixin
+
+                class ProcessingError < StandardError; end
+
+                def call
+                  raise ProcessingError
+                end
+              end
+            end
+          end
+        FILE
+      end
+      let(:expected_file_content) do
+        <<~FILE
+          # frozen_string_literal: true
+
+          module Outer
+            module Inner
+              # == Schema Information
+              #
+              # Table name: users
+              #
+              #  id                     :bigint           not null, primary key
+              #
+              class User < ApplicationRecord
+                include SomeMixin
+
+                class ProcessingError < StandardError; end
+
+                def call
+                  raise ProcessingError
+                end
+              end
+            end
           end
         FILE
       end

--- a/spec/lib/annotate_rb/model_annotator/file_parser/annotation_target_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/file_parser/annotation_target_spec.rb
@@ -2,11 +2,12 @@
 
 RSpec.describe AnnotateRb::ModelAnnotator::FileParser::AnnotationTarget do
   describe ".find" do
-    subject { described_class.find(parser, options) }
+    subject { described_class.find(parser, options, model_class_name: model_class_name) }
 
     let(:parser) { AnnotateRb::ModelAnnotator::FileParser::CustomParser.parse(content) }
     let(:options) { AnnotateRb::Options.new({nested_position: nested_position}) }
     let(:nested_position) { false }
+    let(:model_class_name) { nil }
 
     context "with an empty file" do
       let(:content) { "" }
@@ -138,6 +139,63 @@ RSpec.describe AnnotateRb::ModelAnnotator::FileParser::AnnotationTarget do
         const, line = subject
         expect(const).to eq("Alpha")
         expect(line).to eq(0)
+      end
+    end
+
+    context "with model_class_name set and a matching class declaration" do
+      let(:nested_position) { true }
+      let(:model_class_name) { "Sample" }
+      let(:content) do
+        <<~FILE
+          module Outer
+            class Sample < ApplicationRecord
+              class InnerError < StandardError; end
+              class InnerValue; end
+            end
+          end
+        FILE
+      end
+
+      it "selects the named class instead of an inner class declared later" do
+        const, line = subject
+        expect(const).to eq("Sample")
+        expect(line).to eq(1)
+      end
+    end
+
+    context "with model_class_name that does not match any class in the source" do
+      let(:nested_position) { true }
+      let(:model_class_name) { "Unknown" }
+      let(:content) do
+        <<~FILE
+          class Sample < ApplicationRecord
+            class InnerError < StandardError; end
+          end
+        FILE
+      end
+
+      it "falls back to the deepest class declaration" do
+        const, line = subject
+        expect(const).to eq("InnerError")
+        expect(line).to eq(1)
+      end
+    end
+
+    context "with model_class_name set on a related file that has no class declarations" do
+      let(:nested_position) { true }
+      let(:model_class_name) { "Sample" }
+      let(:content) do
+        <<~FILE
+          require 'rails_helper'
+
+          RSpec.describe Sample do
+          end
+        FILE
+      end
+
+      it "falls back to the first non-require start" do
+        _const, line = subject
+        expect(line).to eq(2)
       end
     end
   end


### PR DESCRIPTION
## Summary

When `nested_position` is enabled, `AnnotationTarget` (introduced in #334) picks the **deepest** class declaration as the insertion point. That heuristic breaks for any model that contains an inner class declaration — custom errors, value objects,
`Struct`/`Data` classes, etc. — because the deepest declaration is the inner one, so the schema annotation gets inserted directly above it instead of above the model class itself.

### Reproduction

```ruby
class Sample < ApplicationRecord
  include SomeMixin

  class ProcessingError < StandardError; end   # ← deepest, wrongly chosen

  def call
    raise ProcessingError
  end
end
```

Running annotaterb with nested_position lands the schema block right above class ProcessingError, not above class Sample.

## Fix

`ProjectAnnotator` already resolves each model file to its actual `ActiveRecord` class via `ModelClassGetter`, so we have the authoritative class name without needing any heuristic. This PR threads `klass.name.demodulize` through:

`SingleFileAnnotatorInstruction` → `SingleFileAnnotator`
→ `ParsedFile` / `AnnotatedFile::Generator`
→ `FileParser::AnnotationTarget.find`

as `model_class_name`:, and `AnnotationTarget.find` matches that name against `parser.type_map` first.

The deepest-declaration heuristic remains as a fallback for the cases where the name is absent or doesn't match anything in the source:

- related files (specs, factories, fixtures) don't get a `model_class_name`
- legacy file/class layouts where the declared class name doesn't match the resolved AR class name

So existing behavior is preserved everywhere except the inner-class case.