### PR TITLE
  Add `position_in_class: after_doc` to keep class doc adjacent to class

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,10 +191,10 @@ Additional options that work for annotating models and routes
     -f [bare|rdoc|yard|markdown],    Render Schema Information as plain/RDoc/Yard/Markdown
         --format
         --config_path [path]         Path to configuration file (by default, .annotaterb.yml in the root of the project)
-    -p [before|top|after|bottom],    Place the annotations at the top (before) or the bottom (after) of the model/test/fixture/factory/route/serializer file(s)
-        --position
-        --pc, --position-in-class [before|top|after|bottom]
-                                     Place the annotations at the top (before) or the bottom (after) of the model file
+    -p [before|top|after|bottom|after_doc],
+        --position                   Place the annotations at the top (before), bottom (after), or above the class documentation (after_doc) of the model/test/fixture/factory/route/serializer file(s)
+        --pc, --position-in-class [before|top|after|bottom|after_doc]
+                                     Place the annotations at the top (before), bottom (after), or above the class documentation (after_doc) of the model file
         --pf, --position-in-factory [before|top|after|bottom]
                                      Place the annotations at the top (before) or the bottom (after) of any factory files
         --px, --position-in-fixture [before|top|after|bottom]
@@ -236,6 +236,35 @@ position: after
 Annotaterb reads first the configuration file, if it exists, passes its content through ERB, and merges the result with any options passed into the CLI.
 
 For further details visit the [section in the migration guide](MIGRATION_GUIDE.md#automatic-annotations-after-running-database-migration-commands).
+
+### Preserving class documentation comments
+
+By default, when `position_in_class` is `before` (or `top`), AnnotateRb places the schema annotation immediately before the class declaration line. Any human-written documentation comment that was directly above the class is therefore pushed above the annotation.
+
+If you prefer to keep the documentation comment adjacent to the class, set `position_in_class` to `after_doc`. The schema annotation is then inserted above the documentation comment block, leaving the comment directly before the class.
+
+```ruby
+# Source file:
+# Doc about User
+class User < ApplicationRecord
+end
+
+# With position_in_class: before  (default)
+# Doc about User
+# == Schema Information
+# ...
+class User < ApplicationRecord
+end
+
+# With position_in_class: after_doc
+# == Schema Information
+# ...
+# Doc about User
+class User < ApplicationRecord
+end
+```
+
+A "documentation comment" is the contiguous comment block immediately above the class declaration, with no blank line between the comments and the class. Recognized magic comments (`encoding`, `frozen_string_literal`, `shareable_constant_value`, `warn_indent`, `typed`, `rbs_inline`, plus Emacs/Vim style modelines) are excluded so the annotation can still be inserted between magic comments and the class doc.
 
 ### How to skip annotating a particular model
 

--- a/README.md
+++ b/README.md
@@ -191,10 +191,10 @@ Additional options that work for annotating models and routes
     -f [bare|rdoc|yard|markdown],    Render Schema Information as plain/RDoc/Yard/Markdown
         --format
         --config_path [path]         Path to configuration file (by default, .annotaterb.yml in the root of the project)
-    -p [before|top|after|bottom|after_doc],
-        --position                   Place the annotations at the top (before), bottom (after), or above the class documentation (after_doc) of the model/test/fixture/factory/route/serializer file(s)
-        --pc, --position-in-class [before|top|after|bottom|after_doc]
-                                     Place the annotations at the top (before), bottom (after), or above the class documentation (after_doc) of the model file
+    -p [before|top|after|bottom|before_doc],
+        --position                   Place the annotations at the top (before), bottom (after), or above the class documentation (before_doc) of the model/test/fixture/factory/route/serializer file(s)
+        --pc, --position-in-class [before|top|after|bottom|before_doc]
+                                     Place the annotations at the top (before), bottom (after), or above the class documentation (before_doc) of the model file
         --pf, --position-in-factory [before|top|after|bottom]
                                      Place the annotations at the top (before) or the bottom (after) of any factory files
         --px, --position-in-fixture [before|top|after|bottom]
@@ -241,7 +241,7 @@ For further details visit the [section in the migration guide](MIGRATION_GUIDE.m
 
 By default, when `position_in_class` is `before` (or `top`), AnnotateRb places the schema annotation immediately before the class declaration line. Any human-written documentation comment that was directly above the class is therefore pushed above the annotation.
 
-If you prefer to keep the documentation comment adjacent to the class, set `position_in_class` to `after_doc`. The schema annotation is then inserted above the documentation comment block, leaving the comment directly before the class.
+If you prefer to keep the documentation comment adjacent to the class, set `position_in_class` to `before_doc`. The schema annotation is then inserted above the documentation comment block, leaving the comment directly before the class.
 
 ```ruby
 # Source file:
@@ -256,7 +256,7 @@ end
 class User < ApplicationRecord
 end
 
-# With position_in_class: after_doc
+# With position_in_class: before_doc
 # == Schema Information
 # ...
 # Doc about User

--- a/lib/annotate_rb/model_annotator/annotated_file/generator.rb
+++ b/lib/annotate_rb/model_annotator/annotated_file/generator.rb
@@ -36,7 +36,7 @@ module AnnotateRb
           # We need to get class start and class end depending on the position
           parsed = @parser.parse(content_without_annotations)
 
-          _content = if %w[after bottom].include?(annotation_write_position)
+          _content = if Parser::AFTER_POSITIONS.include?(annotation_write_position)
             content_annotated_after(parsed, content_without_annotations)
           else
             content_annotated_before(parsed, content_without_annotations, annotation_write_position)
@@ -46,9 +46,13 @@ module AnnotateRb
         private
 
         def content_annotated_before(parsed, content_without_annotations, write_position)
-          same_write_position = @parsed_file.has_annotations? && @parsed_file.annotation_position.to_s == write_position
+          same_write_position = same_side?(write_position)
 
           _constant_name, line_number_before = determine_annotation_position(parsed)
+
+          if Parser::DOC_AWARE_POSITIONS.include?(write_position)
+            line_number_before = class_doc_start_line(content_without_annotations.lines, line_number_before)
+          end
 
           content_with_annotations_written_before = []
           content_with_annotations_written_before << content_without_annotations.lines[0...line_number_before]
@@ -58,6 +62,32 @@ module AnnotateRb
           content_with_annotations_written_before << content_without_annotations.lines[line_number_before..]
 
           content_with_annotations_written_before.join
+        end
+
+        def same_side?(write_position)
+          return false unless @parsed_file.has_annotations?
+
+          new_side = Parser::AFTER_POSITIONS.include?(write_position) ? :after : :before
+          @parsed_file.annotation_position == new_side
+        end
+
+        # Magic comments are excluded so annotations slot between them and
+        # the class doc rather than being treated as part of the doc.
+        def class_doc_start_line(content_lines, line_number_before)
+          doc_start = line_number_before
+          cursor = line_number_before - 1
+
+          while cursor >= 0
+            line = content_lines[cursor]
+            break if line.match?(/\A\s*\z/)
+            break unless line.match?(/\A\s*#/)
+            break if FileParser::MagicComment.match?(line)
+
+            doc_start = cursor
+            cursor -= 1
+          end
+
+          doc_start
         end
 
         def determine_annotation_position(parsed)

--- a/lib/annotate_rb/model_annotator/file_parser.rb
+++ b/lib/annotate_rb/model_annotator/file_parser.rb
@@ -6,6 +6,7 @@ module AnnotateRb
       autoload :AnnotationFinder, "annotate_rb/model_annotator/file_parser/annotation_finder"
       autoload :AnnotationTarget, "annotate_rb/model_annotator/file_parser/annotation_target"
       autoload :CustomParser, "annotate_rb/model_annotator/file_parser/custom_parser"
+      autoload :MagicComment, "annotate_rb/model_annotator/file_parser/magic_comment"
       autoload :ParsedFile, "annotate_rb/model_annotator/file_parser/parsed_file"
       autoload :ParsedFileResult, "annotate_rb/model_annotator/file_parser/parsed_file_result"
       autoload :YmlParser, "annotate_rb/model_annotator/file_parser/yml_parser"

--- a/lib/annotate_rb/model_annotator/file_parser/magic_comment.rb
+++ b/lib/annotate_rb/model_annotator/file_parser/magic_comment.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module AnnotateRb
+  module ModelAnnotator
+    module FileParser
+      module MagicComment
+        DIRECTIVE_KEYS = %w[
+          encoding
+          coding
+          frozen_string_literal
+          warn_indent
+          shareable_constant_value
+          typed
+          rbs_inline
+        ].freeze
+
+        SIMPLE = /\A\s*#\s*(?<key>[A-Za-z][A-Za-z0-9_-]*)\s*:\s*\S/
+        EMACS = /\A\s*#\s*-\*-.*-\*-\s*\z/
+        VIM = /\A\s*#\s*vim:\s/
+
+        def self.match?(line)
+          if (m = SIMPLE.match(line))
+            key = m[:key].downcase.tr("-", "_")
+            return true if DIRECTIVE_KEYS.include?(key)
+          end
+
+          EMACS.match?(line) || VIM.match?(line)
+        end
+      end
+    end
+  end
+end

--- a/lib/annotate_rb/parser.rb
+++ b/lib/annotate_rb/parser.rb
@@ -22,9 +22,9 @@ module AnnotateRb
       exit: false
     }.freeze
 
-    ANNOTATION_POSITIONS = %w[before top after bottom after_doc].freeze
+    ANNOTATION_POSITIONS = %w[before top after bottom before_doc].freeze
     AFTER_POSITIONS = %w[after bottom].freeze
-    DOC_AWARE_POSITIONS = %w[after_doc].freeze
+    DOC_AWARE_POSITIONS = %w[before_doc].freeze
     FILE_TYPE_POSITIONS = %w[position_in_class position_in_factory position_in_fixture position_in_test position_in_routes position_in_serializer].freeze
     EXCLUSION_LIST = %w[tests fixtures factories serializers].freeze
     FORMAT_TYPES = %w[bare rdoc yard markdown].freeze
@@ -299,9 +299,9 @@ module AnnotateRb
       has_set_position = {}
 
       option_parser.on("-p",
-        "--position [before|top|after|bottom|after_doc]",
+        "--position [before|top|after|bottom|before_doc]",
         ANNOTATION_POSITIONS,
-        "Place the annotations at the top (before), bottom (after), or above the class documentation (after_doc) of the model/test/fixture/factory/route/serializer file(s)") do |position|
+        "Place the annotations at the top (before), bottom (after), or above the class documentation (before_doc) of the model/test/fixture/factory/route/serializer file(s)") do |position|
         @options[:position] = position
 
         FILE_TYPE_POSITIONS.each do |key|
@@ -310,9 +310,9 @@ module AnnotateRb
       end
 
       option_parser.on("--pc",
-        "--position-in-class [before|top|after|bottom|after_doc]",
+        "--position-in-class [before|top|after|bottom|before_doc]",
         ANNOTATION_POSITIONS,
-        "Place the annotations at the top (before), bottom (after), or above the class documentation (after_doc) of the model file") do |position_in_class|
+        "Place the annotations at the top (before), bottom (after), or above the class documentation (before_doc) of the model file") do |position_in_class|
         @options[:position_in_class] = position_in_class
         has_set_position["position_in_class"] = true
       end

--- a/lib/annotate_rb/parser.rb
+++ b/lib/annotate_rb/parser.rb
@@ -22,7 +22,9 @@ module AnnotateRb
       exit: false
     }.freeze
 
-    ANNOTATION_POSITIONS = %w[before top after bottom].freeze
+    ANNOTATION_POSITIONS = %w[before top after bottom after_doc].freeze
+    AFTER_POSITIONS = %w[after bottom].freeze
+    DOC_AWARE_POSITIONS = %w[after_doc].freeze
     FILE_TYPE_POSITIONS = %w[position_in_class position_in_factory position_in_fixture position_in_test position_in_routes position_in_serializer].freeze
     EXCLUSION_LIST = %w[tests fixtures factories serializers].freeze
     FORMAT_TYPES = %w[bare rdoc yard markdown].freeze
@@ -297,9 +299,9 @@ module AnnotateRb
       has_set_position = {}
 
       option_parser.on("-p",
-        "--position [before|top|after|bottom]",
+        "--position [before|top|after|bottom|after_doc]",
         ANNOTATION_POSITIONS,
-        "Place the annotations at the top (before) or the bottom (after) of the model/test/fixture/factory/route/serializer file(s)") do |position|
+        "Place the annotations at the top (before), bottom (after), or above the class documentation (after_doc) of the model/test/fixture/factory/route/serializer file(s)") do |position|
         @options[:position] = position
 
         FILE_TYPE_POSITIONS.each do |key|
@@ -308,9 +310,9 @@ module AnnotateRb
       end
 
       option_parser.on("--pc",
-        "--position-in-class [before|top|after|bottom]",
+        "--position-in-class [before|top|after|bottom|after_doc]",
         ANNOTATION_POSITIONS,
-        "Place the annotations at the top (before) or the bottom (after) of the model file") do |position_in_class|
+        "Place the annotations at the top (before), bottom (after), or above the class documentation (after_doc) of the model file") do |position_in_class|
         @options[:position_in_class] = position_in_class
         has_set_position["position_in_class"] = true
       end

--- a/spec/lib/annotate_rb/model_annotator/annotated_file/generator_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/annotated_file/generator_spec.rb
@@ -739,8 +739,8 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotatedFile::Generator do
       end
     end
 
-    context 'when position is "after_doc"' do
-      let(:options) { AnnotateRb::Options.new({position_in_class: "after_doc"}) }
+    context 'when position is "before_doc"' do
+      let(:options) { AnnotateRb::Options.new({position_in_class: "before_doc"}) }
 
       context "when class has no documentation comment" do
         let(:file_content) do
@@ -920,7 +920,7 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotatedFile::Generator do
 
       context "with nested_position and a class doc above the nested class" do
         let(:options) do
-          AnnotateRb::Options.new({position_in_class: "after_doc", nested_position: true})
+          AnnotateRb::Options.new({position_in_class: "before_doc", nested_position: true})
         end
 
         let(:file_content) do

--- a/spec/lib/annotate_rb/model_annotator/annotated_file/generator_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/annotated_file/generator_spec.rb
@@ -739,6 +739,226 @@ RSpec.describe AnnotateRb::ModelAnnotator::AnnotatedFile::Generator do
       end
     end
 
+    context 'when position is "after_doc"' do
+      let(:options) { AnnotateRb::Options.new({position_in_class: "after_doc"}) }
+
+      context "when class has no documentation comment" do
+        let(:file_content) do
+          <<~FILE
+            class User < ApplicationRecord
+            end
+          FILE
+        end
+
+        let(:expected_content) do
+          <<~CONTENT
+            # == Schema Information
+            #
+            # Table name: users
+            #
+            #  id                     :bigint           not null, primary key
+            #
+            class User < ApplicationRecord
+            end
+          CONTENT
+        end
+
+        it "places annotation directly before the class (same as before)" do
+          is_expected.to eq(expected_content)
+        end
+      end
+
+      context "when class has a documentation comment" do
+        let(:file_content) do
+          <<~FILE
+            # My doc about User
+            class User < ApplicationRecord
+            end
+          FILE
+        end
+
+        let(:expected_content) do
+          <<~CONTENT
+            # == Schema Information
+            #
+            # Table name: users
+            #
+            #  id                     :bigint           not null, primary key
+            #
+            # My doc about User
+            class User < ApplicationRecord
+            end
+          CONTENT
+        end
+
+        it "places annotation above the class doc, leaving the doc adjacent to the class" do
+          is_expected.to eq(expected_content)
+        end
+      end
+
+      context "when class has a multi-line documentation comment" do
+        let(:file_content) do
+          <<~FILE
+            # First doc line
+            # Second doc line
+            # Third doc line
+            class User < ApplicationRecord
+            end
+          FILE
+        end
+
+        let(:expected_content) do
+          <<~CONTENT
+            # == Schema Information
+            #
+            # Table name: users
+            #
+            #  id                     :bigint           not null, primary key
+            #
+            # First doc line
+            # Second doc line
+            # Third doc line
+            class User < ApplicationRecord
+            end
+          CONTENT
+        end
+
+        it "preserves the entire contiguous comment block above the class" do
+          is_expected.to eq(expected_content)
+        end
+      end
+
+      context "when class has a magic comment but no class doc" do
+        let(:file_content) do
+          <<~FILE
+            # frozen_string_literal: true
+            class User < ApplicationRecord
+            end
+          FILE
+        end
+
+        let(:expected_content) do
+          <<~CONTENT
+            # frozen_string_literal: true
+            # == Schema Information
+            #
+            # Table name: users
+            #
+            #  id                     :bigint           not null, primary key
+            #
+            class User < ApplicationRecord
+            end
+          CONTENT
+        end
+
+        it "treats magic comments as non-doc and inserts annotation between them and the class" do
+          is_expected.to eq(expected_content)
+        end
+      end
+
+      context "when class has a magic comment and a class doc adjacent to each other" do
+        let(:file_content) do
+          <<~FILE
+            # frozen_string_literal: true
+            # My doc about User
+            class User < ApplicationRecord
+            end
+          FILE
+        end
+
+        let(:expected_content) do
+          <<~CONTENT
+            # frozen_string_literal: true
+            # == Schema Information
+            #
+            # Table name: users
+            #
+            #  id                     :bigint           not null, primary key
+            #
+            # My doc about User
+            class User < ApplicationRecord
+            end
+          CONTENT
+        end
+
+        it "inserts annotation between magic comment and class doc" do
+          is_expected.to eq(expected_content)
+        end
+      end
+
+      context "when there is an unrelated comment block separated from the class by a blank line" do
+        let(:file_content) do
+          <<~FILE
+            # Top-level note
+
+            # My doc about User
+            class User < ApplicationRecord
+            end
+          FILE
+        end
+
+        let(:expected_content) do
+          <<~CONTENT
+            # Top-level note
+
+            # == Schema Information
+            #
+            # Table name: users
+            #
+            #  id                     :bigint           not null, primary key
+            #
+            # My doc about User
+            class User < ApplicationRecord
+            end
+          CONTENT
+        end
+
+        it "treats blank-line separated comments as not class doc" do
+          is_expected.to eq(expected_content)
+        end
+      end
+
+      context "with nested_position and a class doc above the nested class" do
+        let(:options) do
+          AnnotateRb::Options.new({position_in_class: "after_doc", nested_position: true})
+        end
+
+        let(:file_content) do
+          <<~FILE
+            # frozen_string_literal: true
+
+            module Collapsed
+              # Doc about TestModel
+              class TestModel < ApplicationRecord
+              end
+            end
+          FILE
+        end
+
+        let(:expected_content) do
+          <<~CONTENT
+            # frozen_string_literal: true
+
+            module Collapsed
+              # == Schema Information
+              #
+              # Table name: users
+              #
+              #  id                     :bigint           not null, primary key
+              #
+              # Doc about TestModel
+              class TestModel < ApplicationRecord
+              end
+            end
+          CONTENT
+        end
+
+        it "preserves the doc adjacent to the nested class" do
+          is_expected.to eq(expected_content)
+        end
+      end
+    end
+
     context "when file is empty" do
       let(:file_content) { "" }
       let(:new_annotations) do

--- a/spec/lib/annotate_rb/model_annotator/annotating_a_file_with_comments_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/annotating_a_file_with_comments_spec.rb
@@ -1748,6 +1748,141 @@ RSpec.describe "Annotating a file with comments" do
     end
   end
 
+  context "when annotating with position_in_class: after_doc" do
+    let(:options) { AnnotateRb::Options.from({position_in_class: "after_doc"}) }
+
+    context "with a class doc directly above the class" do
+      let(:starting_file_content) do
+        <<~FILE
+          # My doc about User
+          class User < ApplicationRecord
+          end
+        FILE
+      end
+      let(:expected_file_content) do
+        <<~FILE
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id                     :bigint           not null, primary key
+          #
+          # My doc about User
+          class User < ApplicationRecord
+          end
+        FILE
+      end
+
+      include_examples "annotates the file"
+    end
+
+    context "with a magic comment and a class doc" do
+      let(:starting_file_content) do
+        <<~FILE
+          # frozen_string_literal: true
+
+          # My doc about User
+          class User < ApplicationRecord
+          end
+        FILE
+      end
+      let(:expected_file_content) do
+        <<~FILE
+          # frozen_string_literal: true
+
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id                     :bigint           not null, primary key
+          #
+          # My doc about User
+          class User < ApplicationRecord
+          end
+        FILE
+      end
+
+      include_examples "annotates the file"
+    end
+
+    context "when re-running on a file already annotated with after_doc" do
+      let(:schema_info) do
+        <<~SCHEMA
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id                     :bigint           not null, primary key
+          #  boolean                :boolean          default(FALSE)
+          #
+        SCHEMA
+      end
+
+      let(:starting_file_content) do
+        <<~FILE
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id                     :bigint           not null, primary key
+          #
+          # My doc about User
+          class User < ApplicationRecord
+          end
+        FILE
+      end
+      let(:expected_file_content) do
+        <<~FILE
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id                     :bigint           not null, primary key
+          #  boolean                :boolean          default(FALSE)
+          #
+          # My doc about User
+          class User < ApplicationRecord
+          end
+        FILE
+      end
+
+      include_examples "annotates the file"
+    end
+
+    context "when migrating an existing 'before' annotation to 'after_doc' with --force" do
+      let(:options) { AnnotateRb::Options.from({position_in_class: "after_doc", force: true}) }
+
+      let(:starting_file_content) do
+        <<~FILE
+          # My doc about User
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id                     :bigint           not null, primary key
+          #
+          class User < ApplicationRecord
+          end
+        FILE
+      end
+      let(:expected_file_content) do
+        <<~FILE
+          # == Schema Information
+          #
+          # Table name: users
+          #
+          #  id                     :bigint           not null, primary key
+          #
+          # My doc about User
+          class User < ApplicationRecord
+          end
+        FILE
+      end
+
+      include_examples "annotates the file"
+    end
+  end
+
   context "when annotating a model with inner class declarations and nested_position" do
     let(:options) do
       AnnotateRb::Options.from({nested_position: true, force: true})

--- a/spec/lib/annotate_rb/model_annotator/annotating_a_file_with_comments_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/annotating_a_file_with_comments_spec.rb
@@ -1748,8 +1748,8 @@ RSpec.describe "Annotating a file with comments" do
     end
   end
 
-  context "when annotating with position_in_class: after_doc" do
-    let(:options) { AnnotateRb::Options.from({position_in_class: "after_doc"}) }
+  context "when annotating with position_in_class: before_doc" do
+    let(:options) { AnnotateRb::Options.from({position_in_class: "before_doc"}) }
 
     context "with a class doc directly above the class" do
       let(:starting_file_content) do
@@ -1805,7 +1805,7 @@ RSpec.describe "Annotating a file with comments" do
       include_examples "annotates the file"
     end
 
-    context "when re-running on a file already annotated with after_doc" do
+    context "when re-running on a file already annotated with before_doc" do
       let(:schema_info) do
         <<~SCHEMA
           # == Schema Information
@@ -1849,8 +1849,8 @@ RSpec.describe "Annotating a file with comments" do
       include_examples "annotates the file"
     end
 
-    context "when migrating an existing 'before' annotation to 'after_doc' with --force" do
-      let(:options) { AnnotateRb::Options.from({position_in_class: "after_doc", force: true}) }
+    context "when migrating an existing 'before' annotation to 'before_doc' with --force" do
+      let(:options) { AnnotateRb::Options.from({position_in_class: "before_doc", force: true}) }
 
       let(:starting_file_content) do
         <<~FILE

--- a/spec/lib/annotate_rb/model_annotator/file_parser/magic_comment_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/file_parser/magic_comment_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+RSpec.describe AnnotateRb::ModelAnnotator::FileParser::MagicComment do
+  describe ".match?" do
+    subject { described_class.match?(line) }
+
+    context "with simple style magic comments" do
+      [
+        "# encoding: UTF-8",
+        "# coding: UTF-8",
+        "# frozen_string_literal: true",
+        "# frozen-string-literal: false",
+        "# warn_indent: true",
+        "# shareable_constant_value: literal",
+        "# shareable-constant-value: experimental_everything",
+        "# typed: true",
+        "# typed: strict",
+        "# typed: ignore",
+        "# rbs_inline: enabled",
+        "# rbs_inline: disabled"
+      ].each do |line|
+        context "when line is #{line.inspect}" do
+          let(:line) { line }
+          it { is_expected.to be true }
+        end
+      end
+    end
+
+    context "with surrounding whitespace and trailing content" do
+      let(:line) { "  #   frozen_string_literal:    true   " }
+      it { is_expected.to be true }
+    end
+
+    context "with Emacs style magic comment" do
+      let(:line) { "# -*- coding: utf-8; frozen_string_literal: true -*-" }
+      it { is_expected.to be true }
+    end
+
+    context "with Vim style modeline" do
+      let(:line) { "# vim: fileencoding=utf-8 ft=ruby" }
+      it { is_expected.to be true }
+    end
+
+    context "with a normal class documentation comment" do
+      let(:line) { "# Represents a registered user account" }
+      it { is_expected.to be false }
+    end
+
+    context "with a comment that has a colon but no recognized key" do
+      let(:line) { "# Note: this comment is not a magic comment" }
+      it { is_expected.to be false }
+    end
+
+    context "with a YARD style tag comment" do
+      let(:line) { "# @return [String]" }
+      it { is_expected.to be false }
+    end
+
+    context "with a non-comment line" do
+      let(:line) { "class User < ApplicationRecord" }
+      it { is_expected.to be false }
+    end
+
+    context "with a blank line" do
+      let(:line) { "" }
+      it { is_expected.to be false }
+    end
+
+    context "with an empty comment marker" do
+      let(:line) { "#" }
+      it { is_expected.to be false }
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes drwl/annotaterb#201.

Add a new `after_doc` value for `position_in_class` (and the other `position_in_*` options). When set, the schema annotation is inserted **above the contiguous documentation comment block** that sits directly above the class declaration, so the human-written doc stays adjacent to the class.

The default behavior (`before` / `top`) is unchanged.

## Problem

With the existing `before` / `top` positions, a documentation comment placed directly above the class declaration gets pushed above the schema annotation — away from the class it documents:

```ruby
# Source file:
# Doc about User
class User < ApplicationRecord
end

# After annotaterb today:
# Doc about User
# == Schema Information
# ...
class User < ApplicationRecord
end
```

 ## Fix

 Setting `position_in_class: after_doc` slots the annotation above the doc block, keeping the doc next to the class:

 ```ruby
 # With position_in_class: after_doc:
 # == Schema Information
 # ...
 # Doc about User
 class User < ApplicationRecord
 end
 ```

 A "documentation comment" is defined as the contiguous comment block immediately above the class declaration with no blank line between. Recognized magic comments (`encoding`, `frozen_string_literal`, `shareable_constant_value`, `warn_indent`, `typed`, `rbs_inline`, plus Emacs/Vim modelines) are excluded so the annotation still slots between magic comments and the class doc:

 ```ruby
 # Source file:
 # frozen_string_literal: true
 # Doc about User
 class User < ApplicationRecord
 end

 # With position_in_class: after_doc:
 # frozen_string_literal: true
 # == Schema Information
 # ...
 # Doc about User
 class User < ApplicationRecord
 end
 ```
