### PR TITLE
Fix annotation inserted inside module when doc comment is present

### DIFF
--- a/lib/annotate_rb/model_annotator/file_parser/custom_parser.rb
+++ b/lib/annotate_rb/model_annotator/file_parser/custom_parser.rb
@@ -50,16 +50,23 @@ module AnnotateRb
           }
         end
 
+        def on_const(const)
+          @_last_const_lineno = lineno
+          super
+        end
+
         def on_const_ref(const)
-          add_event(__method__, const, lineno)
-          @block_starts << [const, lineno]
+          declaration_lineno = @_last_const_lineno || lineno
+          add_event(__method__, const, declaration_lineno)
+          @block_starts << [const, declaration_lineno]
           super
         end
 
         # Used for `class Foo::User`
         def on_const_path_ref(_left, const)
-          add_event(__method__, const, lineno)
-          @block_starts << [const, lineno]
+          declaration_lineno = @_last_const_lineno || lineno
+          add_event(__method__, const, declaration_lineno)
+          @block_starts << [const, declaration_lineno]
           super
         end
 

--- a/spec/lib/annotate_rb/model_annotator/file_parser/custom_parser_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/file_parser/custom_parser_spec.rb
@@ -78,6 +78,32 @@ RSpec.describe AnnotateRb::ModelAnnotator::FileParser::CustomParser do
       end
     end
 
+    context "when class is namespaced in a module with a doc comment inside the module" do
+      let(:input) do
+        <<~FILE
+          # frozen_string_literal: true
+
+          module Collapsed
+            # Doc about TestModel
+            class TestModel < ApplicationRecord
+            end
+          end
+        FILE
+      end
+      let(:expected_comments) do
+        [
+          ["# frozen_string_literal: true", 0],
+          ["# Doc about TestModel", 3]
+        ]
+      end
+      let(:expected_starts) { [["Collapsed", 2], ["TestModel", 4]] }
+      let(:expected_ends) { [["TestModel", 5], ["Collapsed", 6]] }
+
+      it "parses the module start at the correct line number" do
+        check_it_parses_correctly
+      end
+    end
+
     context "when class is namespaced in a module with comments" do
       let(:input) do
         <<~FILE


### PR DESCRIPTION
## Summary
Fix incorrect line number for module declarations followed by a comment

## Problem
When a module declaration is followed by a doc comment inside the module, the schema annotation is inserted after the module keyword line (i.e. inside the module) rather than before it.

```rb
# frozen_string_literal: true

module Collapsed
  # Doc about TestModel   ← this comment causes the issue
  class TestModel < ApplicationRecord
  end
end
```

`on_const_ref` is a parser event that fires after the scanner has already advanced past the comment line, so lineno returns 3 instead of 2 for module Collapsed. As a result, lines[0...3] includes the module Collapsed line itself, pushing the annotation inside the module.

Running `bundle exec annotaterb models` on the above file produces:

```rb
# frozen_string_literal: true

module Collapsed
# == Schema Information
# ...
  # Doc about TestModel
  class TestModel < ApplicationRecord
  end
end
```

## Solution
Introduce `on_const` (a scanner event) to capture the line number at the exact moment the constant token is scanned. `on_const_ref` and `on_const_path_ref` now use this saved value instead of lineno.