### PR TITLE
Fix NameError in ZeitwerkClassGetter for collapsed Zeitwerk paths

### DIFF
--- a/lib/annotate_rb/model_annotator/zeitwerk_class_getter.rb
+++ b/lib/annotate_rb/model_annotator/zeitwerk_class_getter.rb
@@ -49,7 +49,7 @@ module AnnotateRb
 
         # once we have the filepath_relative_to_root_dir, we need to see if it
         # falls within one of our Zeitwerk "collapsed" paths.
-        if loader.collapse.any? { |path| path.include?(root_dir) && file.include?(path.split(root_dir)[1]) }
+        if loader.collapse.any? { |path| path.include?(root_dir) && @file.include?(path.split(root_dir)[1]) }
           # if the file is within a collapsed path, we then need to, for each
           # collapsed path, remove the root dir
           collapsed = loader.collapse.map { |path| path.split(root_dir)[1].sub(/^\//, "") }.to_set


### PR DESCRIPTION
## Summary
Got an error when running annotaterb:
```
undefined local variable or method 'file' for an instance of AnnotateRb::ModelAnnotator::ZeitwerkClassGetter
undefined local variable or method 'file' for an instance of AnnotateRb::ModelAnnotator::ZeitwerkClassGetter
undefined local variable or method 'file' for an instance of AnnotateRb::ModelAnnotator::ZeitwerkClassGetter
undefined local variable or method 'file' for an instance of AnnotateRb::ModelAnnotator::ZeitwerkClassGetter
undefined local variable or method 'file' for an instance of AnnotateRb::ModelAnnotator::ZeitwerkClassGetter
undefined local variable or method 'file' for an instance of AnnotateRb::ModelAnnotator::ZeitwerkClassGetter
undefined local variable or method 'file' for an instance of AnnotateRb::ModelAnnotator::ZeitwerkClassGetter
```

The block on line 52 referenced a local variable `file` that does not exist in this scope. Any model file falling inside a Zeitwerk `collapse` path raised `NameError: undefined local variable or method 'file'`, which was swallowed by the `rescue NameError` on line 77 and returned `nil`, silently breaking annotation for collapsed-path models.

## Change
`lib/annotate_rb/model_annotator/zeitwerk_class_getter.rb:52` — `file.include?(...)` → `@file.include?(...)`.