### PR TITLE
Fix update_config for non-default config locations

### DIFF
--- a/lib/generators/annotate_rb/update_config/update_config_generator.rb
+++ b/lib/generators/annotate_rb/update_config/update_config_generator.rb
@@ -6,7 +6,10 @@ module AnnotateRb
   module Generators
     class UpdateConfigGenerator < ::Rails::Generators::Base
       def generate_config
-        insert_into_file ::AnnotateRb::ConfigFinder::DOTFILE do
+        parsed_options = AnnotateRb::Parser.parse(ARGV, {})
+        AnnotateRb::ConfigFinder.config_path = parsed_options[:config_path] if parsed_options[:config_path]
+
+        insert_into_file ::AnnotateRb::ConfigFinder.find_project_dotfile do
           ::AnnotateRb::ConfigGenerator.unset_config_defaults
         end
       end

--- a/spec/integration/rails_generator_update_config_spec.rb
+++ b/spec/integration/rails_generator_update_config_spec.rb
@@ -3,9 +3,16 @@
 require "integration_spec_helper"
 
 RSpec.describe "Generator appends to config file", type: "aruba" do
+  supported_config_files = [
+    "config/annotaterb.yml",
+    ".config/.annotaterb.yml",
+    ".config/annotaterb/config.yml"
+  ]
+
   let(:command_timeout_seconds) { 10 }
 
   let(:config_file) { ".annotaterb.yml" }
+  let(:custom_config_file) { "custom_annotaterb.yml" }
   let(:config_file_content) do
     <<~YML.strip
       ---
@@ -36,5 +43,36 @@ RSpec.describe "Generator appends to config file", type: "aruba" do
 
     expect(last_command_started).to be_successfully_executed
     expect(config_file_content).not_to eq(changed_config_file)
+  end
+
+  supported_config_files.each do |supported_config_file|
+    it "appends missing configuration key-value pairs to #{supported_config_file}" do
+      write_file(supported_config_file, config_file_content)
+
+      _cmd = run_command_and_stop(generator_update_config_command, fail_on_error: true, exit_timeout: command_timeout_seconds)
+
+      changed_config_file = read_file(supported_config_file)
+
+      expect(last_command_started).to be_successfully_executed
+      expect(config_file_content).not_to eq(changed_config_file)
+    end
+  end
+
+  it "appends missing configuration key-value pairs to the config file specified by --config-path" do
+    write_file(config_file, config_file_content)
+    write_file(custom_config_file, config_file_content)
+
+    _cmd = run_command_and_stop(
+      "#{generator_update_config_command} --config-path=#{custom_config_file}",
+      fail_on_error: true,
+      exit_timeout: command_timeout_seconds
+    )
+
+    changed_default_config_file = read_file(config_file)
+    changed_custom_config_file = read_file(custom_config_file)
+
+    expect(last_command_started).to be_successfully_executed
+    expect(changed_default_config_file).to eq(config_file_content)
+    expect(changed_custom_config_file).not_to eq(config_file_content)
   end
 end


### PR DESCRIPTION
## Problem
The update_config generator always targeted the fixed `.annotaterb.yml` path. When a project stored its annotaterb config in another supported location, running update_config did not update that actual config file.

## Solution
Resolve the target config file through ConfigFinder.find_project_dotfile. Also honor `--config-path` by setting `ConfigFinder.config_path` before resolving the file to update.