### PR TITLE
Add Rails version matrix to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       matrix:
         adapter: [ 'mysql2', 'pg', 'sqlite3' ]
         ruby: ['3.3', '3.4', '4.0']
+        rails: ['~> 7.2.0', '~> 8.0.0', '~> 8.1.0']
 
     steps:
       - name: Checkout
@@ -68,19 +69,22 @@ jobs:
         run: bundle config set path 'vendor/bundle'
         working-directory: spec/dummyapp
 
-      - name: Install dummyapp dependencies (${{ matrix.adapter }})
+      - name: Install dummyapp dependencies (${{ matrix.adapter }}, Rails ${{ matrix.rails }})
         run: bundle install
         working-directory: spec/dummyapp
         env:
           DATABASE_ADAPTER: ${{ matrix.adapter }}
+          RAILS_VERSION: ${{ matrix.rails }}
 
-      - name: Run dummyapp migrations (${{ matrix.adapter }})
+      - name: Run dummyapp migrations (${{ matrix.adapter }}, Rails ${{ matrix.rails }})
         run: bin/rails db:create
         working-directory: spec/dummyapp
         env:
           DATABASE_ADAPTER: ${{ matrix.adapter }}
+          RAILS_VERSION: ${{ matrix.rails }}
 
-      - name: Run Integration tests (${{ matrix.adapter }})
+      - name: Run Integration tests (${{ matrix.adapter }}, Rails ${{ matrix.rails }})
         run: bundle exec rake spec:integration
         env:
           DATABASE_ADAPTER: ${{ matrix.adapter }}
+          RAILS_VERSION: ${{ matrix.rails }}

--- a/spec/dummyapp/Gemfile
+++ b/spec/dummyapp/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
-gem "rails", "~> 7.1.0"
+gem "rails", ENV.fetch("RAILS_VERSION", "~> 7.2.0")
 
 case ENV['DATABASE_ADAPTER'] # This feels so wrong
 when 'mysql2'
@@ -10,7 +10,11 @@ when 'mysql2'
 when 'pg'
   gem 'pg', '>= 1.5', '< 2'
 when 'sqlite3'
-  gem 'sqlite3', '>= 1.6', '< 2'
+  if ENV.fetch("RAILS_VERSION", "~> 7.2.0")[/(\d+)\./, 1].to_i >= 8
+    gem 'sqlite3', '>= 2.1'
+  else
+    gem 'sqlite3', '>= 1.6', '< 2'
+  end
 else
   raise 'The environment variable DATABASE_ADAPTER must be one of mysql2, pg, or sqlite3'
 end

--- a/spec/support/aruba.rb
+++ b/spec/support/aruba.rb
@@ -18,6 +18,14 @@ module SpecHelper
     end
 
     def model_template(name)
+      # Rails 8 changed TimeWithZone#inspect to ISO 8601 (https://github.com/rails/rails/pull/52371),
+      # so datetime defaults in schema comments differ from Rails 7.2. spec/templates/rails8/
+      # holds those overrides; if we drop Rails 7.2 from the CI matrix, this branch can go away.
+      if ENV.fetch("RAILS_VERSION", "~> 7.2.0")[/(\d+)\./, 1].to_i >= 8
+        rails8_path = File.join(::Aruba.config.root_directory, "spec/templates/rails8/#{ENV["DATABASE_ADAPTER"]}", name)
+        return rails8_path if File.exist?(rails8_path)
+      end
+
       File.join(models_template_dir, name)
     end
 

--- a/spec/templates/rails8/mysql2/test_default.rb
+++ b/spec/templates/rails8/mysql2/test_default.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: test_defaults
+#
+#  id         :bigint           not null, primary key
+#  boolean    :boolean          default(FALSE)
+#  date       :date             default(Tue, 04 Jul 2023)
+#  datetime   :datetime         default(2023-07-04 12:34:56.000000000 UTC +00:00)
+#  decimal    :decimal(14, 2)   default(43.21)
+#  float      :float(24)        default(12.34)
+#  integer    :integer          default(99)
+#  string     :string(255)      default("hello world!")
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class TestDefault < ApplicationRecord
+end

--- a/spec/templates/rails8/mysql2/test_default_updated.rb
+++ b/spec/templates/rails8/mysql2/test_default_updated.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: test_defaults
+#
+#  id         :bigint           not null, primary key
+#  boolean    :boolean          default(FALSE)
+#  date       :date             default(Tue, 04 Jul 2023)
+#  datetime   :datetime         default(2023-07-04 12:34:56.000000000 UTC +00:00)
+#  decimal    :decimal(14, 2)   default(43.21)
+#  float      :float(24)        default(12.34)
+#  int_field  :integer
+#  integer    :integer          default(99)
+#  string     :string(255)      default("hello world!")
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class TestDefault < ApplicationRecord
+end

--- a/spec/templates/rails8/mysql2/test_default_with_bottom_annotations.rb
+++ b/spec/templates/rails8/mysql2/test_default_with_bottom_annotations.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+class TestDefault < ApplicationRecord
+end
+
+# == Schema Information
+#
+# Table name: test_defaults
+#
+#  id         :bigint           not null, primary key
+#  boolean    :boolean          default(FALSE)
+#  date       :date             default(Tue, 04 Jul 2023)
+#  datetime   :datetime         default(2023-07-04 12:34:56.000000000 UTC +00:00)
+#  decimal    :decimal(14, 2)   default(43.21)
+#  float      :float(24)        default(12.34)
+#  integer    :integer          default(99)
+#  string     :string(255)      default("hello world!")
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#

--- a/spec/templates/rails8/mysql2/test_sibling_default.rb
+++ b/spec/templates/rails8/mysql2/test_sibling_default.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: test_defaults
+#
+#  id         :bigint           not null, primary key
+#  boolean    :boolean          default(FALSE)
+#  date       :date             default(Tue, 04 Jul 2023)
+#  datetime   :datetime         default(2023-07-04 12:34:56.000000000 UTC +00:00)
+#  decimal    :decimal(14, 2)   default(43.21)
+#  float      :float(24)        default(12.34)
+#  integer    :integer          default(99)
+#  string     :string(255)      default("hello world!")
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class TestSiblingDefault < TestDefault
+end

--- a/spec/templates/rails8/pg/test_default.rb
+++ b/spec/templates/rails8/pg/test_default.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: test_defaults
+#
+#  id         :bigint           not null, primary key
+#  boolean    :boolean          default(FALSE)
+#  date       :date             default(Tue, 04 Jul 2023)
+#  datetime   :datetime         default(2023-07-04 12:34:56.000000000 UTC +00:00)
+#  decimal    :decimal(14, 2)   default(43.21)
+#  float      :float            default(12.34)
+#  integer    :integer          default(99)
+#  string     :string           default("hello world!")
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class TestDefault < ApplicationRecord
+end

--- a/spec/templates/rails8/pg/test_default_updated.rb
+++ b/spec/templates/rails8/pg/test_default_updated.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: test_defaults
+#
+#  id         :bigint           not null, primary key
+#  boolean    :boolean          default(FALSE)
+#  date       :date             default(Tue, 04 Jul 2023)
+#  datetime   :datetime         default(2023-07-04 12:34:56.000000000 UTC +00:00)
+#  decimal    :decimal(14, 2)   default(43.21)
+#  float      :float            default(12.34)
+#  int_field  :integer
+#  integer    :integer          default(99)
+#  string     :string           default("hello world!")
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class TestDefault < ApplicationRecord
+end

--- a/spec/templates/rails8/pg/test_default_with_bottom_annotations.rb
+++ b/spec/templates/rails8/pg/test_default_with_bottom_annotations.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+class TestDefault < ApplicationRecord
+end
+
+# == Schema Information
+#
+# Table name: test_defaults
+#
+#  id         :bigint           not null, primary key
+#  boolean    :boolean          default(FALSE)
+#  date       :date             default(Tue, 04 Jul 2023)
+#  datetime   :datetime         default(2023-07-04 12:34:56.000000000 UTC +00:00)
+#  decimal    :decimal(14, 2)   default(43.21)
+#  float      :float            default(12.34)
+#  integer    :integer          default(99)
+#  string     :string           default("hello world!")
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#

--- a/spec/templates/rails8/pg/test_sibling_default.rb
+++ b/spec/templates/rails8/pg/test_sibling_default.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: test_defaults
+#
+#  id         :bigint           not null, primary key
+#  boolean    :boolean          default(FALSE)
+#  date       :date             default(Tue, 04 Jul 2023)
+#  datetime   :datetime         default(2023-07-04 12:34:56.000000000 UTC +00:00)
+#  decimal    :decimal(14, 2)   default(43.21)
+#  float      :float            default(12.34)
+#  integer    :integer          default(99)
+#  string     :string           default("hello world!")
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class TestSiblingDefault < TestDefault
+end

--- a/spec/templates/rails8/sqlite3/test_default.rb
+++ b/spec/templates/rails8/sqlite3/test_default.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: test_defaults
+#
+#  id         :integer          not null, primary key
+#  boolean    :boolean          default(FALSE)
+#  date       :date             default(Tue, 04 Jul 2023)
+#  datetime   :datetime         default(2023-07-04 12:34:56.000000000 UTC +00:00)
+#  decimal    :decimal(14, 2)   default(43.21)
+#  float      :float            default(12.34)
+#  integer    :integer          default(99)
+#  string     :string           default("hello world!")
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class TestDefault < ApplicationRecord
+end

--- a/spec/templates/rails8/sqlite3/test_default_updated.rb
+++ b/spec/templates/rails8/sqlite3/test_default_updated.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: test_defaults
+#
+#  id         :integer          not null, primary key
+#  boolean    :boolean          default(FALSE)
+#  date       :date             default(Tue, 04 Jul 2023)
+#  datetime   :datetime         default(2023-07-04 12:34:56.000000000 UTC +00:00)
+#  decimal    :decimal(14, 2)   default(43.21)
+#  float      :float            default(12.34)
+#  int_field  :integer
+#  integer    :integer          default(99)
+#  string     :string           default("hello world!")
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class TestDefault < ApplicationRecord
+end

--- a/spec/templates/rails8/sqlite3/test_default_with_bottom_annotations.rb
+++ b/spec/templates/rails8/sqlite3/test_default_with_bottom_annotations.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+class TestDefault < ApplicationRecord
+end
+
+# == Schema Information
+#
+# Table name: test_defaults
+#
+#  id         :integer          not null, primary key
+#  boolean    :boolean          default(FALSE)
+#  date       :date             default(Tue, 04 Jul 2023)
+#  datetime   :datetime         default(2023-07-04 12:34:56.000000000 UTC +00:00)
+#  decimal    :decimal(14, 2)   default(43.21)
+#  float      :float            default(12.34)
+#  integer    :integer          default(99)
+#  string     :string           default("hello world!")
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#

--- a/spec/templates/rails8/sqlite3/test_sibling_default.rb
+++ b/spec/templates/rails8/sqlite3/test_sibling_default.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: test_defaults
+#
+#  id         :integer          not null, primary key
+#  boolean    :boolean          default(FALSE)
+#  date       :date             default(Tue, 04 Jul 2023)
+#  datetime   :datetime         default(2023-07-04 12:34:56.000000000 UTC +00:00)
+#  decimal    :decimal(14, 2)   default(43.21)
+#  float      :float            default(12.34)
+#  integer    :integer          default(99)
+#  string     :string           default("hello world!")
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class TestSiblingDefault < TestDefault
+end


### PR DESCRIPTION
##   Summary
Extend integration CI to run against Rails 7.2, 8.0, and 8.1 across all database adapters. 
Add Rails 8–specific expected-output templates only where schema annotation formatting differs (mainly datetime defaults), while keeping existing templates as the default fallback.

## Problem
Integration tests were pinned to a single Rails version (~> 7.1.0), so regressions on newer Rails releases could go unnoticed. When running against Rails 8, some integration specs failed because Rails 8 changed how datetime default values appear in schema annotations (e.g. nanosecond precision and UTC suffix). Updating every template globally would add noise and break expectations for older Rails
versions.

## Solution
• Add a rails dimension to the integration CI  matrix and pass RAILS_VERSION through dummyapp  setup and test execution.
• Make the dummyapp Gemfile respect RAILS_VERSION,  and allow sqlite3 2.x when testing Rails 8.
• Teach SpecHelper::Aruba#model_template to prefer  spec/templates/rails8/<adapter>/ when running on  Rails 8 and an override exists; otherwise fall back to the existing spec/templates/<adapter>/templates.
• Add Rails 8 overrides only for the specs that compare datetime output (12 files total), avoiding unnecessary duplication of the full template set.

## Note
The spec/templates/rails8/ overrides exist solely because Rails 8 changed how datetime default values are rendered in schema comments. This comes from rails/rails#52371(https://github.com/rails/rails/pull/52371), which updated TimeWithZone#inspect to use ISO 8601-style formatting (e.g. 2023-07-04 12:34:56...) instead of the RFC 822-style format used on Rails 7.2 and earlier (e.g. Tue, 04 Jul 2023 12:34:56...).

As long as we keep Rails 7.2 in the CI matrix, we need separate golden files for the specs that assert datetime defaults. If we drop Rails 7.2 support later, every tested Rails version would share the same output format, and we could remove the rails8/ directory and the version-specific template lookup in model_template — the matrix CI would still work with a single set of templates.