### PR TITLE
Fix schema_like? to recognize markdown-formatted annotation rows

### DIFF
--- a/lib/annotate_rb/model_annotator/file_parser/annotation_finder.rb
+++ b/lib/annotate_rb/model_annotator/file_parser/annotation_finder.rb
@@ -19,8 +19,16 @@ module AnnotateRb
         SCHEMA_HEADER_EXACT = [
           IndexAnnotation::Annotation::HEADER_TEXT,
           ForeignKeyAnnotation::Annotation::HEADER_TEXT,
-          CheckConstraintAnnotation::Annotation::HEADER_TEXT
+          CheckConstraintAnnotation::Annotation::HEADER_TEXT,
+          EnumAnnotation::Annotation::HEADER_TEXT
         ].freeze
+
+        # `format_markdown: true` renders each of the section headers above as
+        # "### <name>" instead of "<name>", so SCHEMA_HEADER_EXACT can't match it directly.
+        # There's no HEADER_TEXT constant for the columns table itself,
+        # so "Columns" is listed explicitly here.
+        MARKDOWN_HEADER_PREFIX = "### "
+        MARKDOWN_SECTION_HEADERS = (SCHEMA_HEADER_EXACT + ["Columns"]).freeze
 
         class MalformedAnnotation < StandardError; end
 
@@ -118,7 +126,18 @@ module AnnotateRb
           ending
         end
 
-        # Tabular rows have ≥2 leading spaces after `#`; prose has at most one.
+        # A line is part of the schema block if it matches one of the known
+        # header prefixes/exact texts, or if it looks like a tabular/list row
+        # of the annotation body:
+        #
+        # - Default/plain format: rows have >= 2 leading spaces after `#`
+        #   (e.g. "#  id  :integer  not null"); prose has at most one.
+        # - Markdown format (`format_markdown: true`) instead uses a single
+        #   leading space after `#` for everything, so it needs its own
+        #   detection: "### <name>" section headers (matched against
+        #   MARKDOWN_SECTION_HEADERS with the prefix stripped), "|"-delimited
+        #   table rows (header/divider/data), and "* `...`" bulleted list
+        #   items for indexes/foreign keys/enums.
         def schema_like?(comment)
           return true if comment == DEFAULT_ANNOTATION_ENDING
 
@@ -127,6 +146,21 @@ module AnnotateRb
 
           return true if SCHEMA_HEADER_PREFIXES.any? { |p| text.start_with?(p) }
           return true if SCHEMA_HEADER_EXACT.include?(text)
+
+          # Markdown section headers, e.g. "### Columns", "### Indexes".
+          if text.start_with?(MARKDOWN_HEADER_PREFIX)
+            return MARKDOWN_SECTION_HEADERS.include?(text.delete_prefix(MARKDOWN_HEADER_PREFIX))
+          end
+
+          # Requires at least two | separators to identify Markdown tables.
+          # This prevents normal user comments containing a single | from being mistaken for a table.
+          return true if text.count("|") >= 2
+
+          # Markdown bulleted list items used for foreign keys/indexes/enums,
+          # e.g. "* `index_name`:" or the nested "    * **`column`**". The
+          # backtick right after the bullet marker distinguishes these from
+          # an unrelated user comment that starts with a plain "* ".
+          return true if text.match?(/\A\s*\*\s+\*{0,2}`/)
 
           comment.match?(/\A#\s{2,}\S/)
         end

--- a/spec/lib/annotate_rb/model_annotator/annotating_a_file_with_comments_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/annotating_a_file_with_comments_spec.rb
@@ -1939,4 +1939,58 @@ RSpec.describe "Annotating a file with comments" do
       include_examples "annotates the file"
     end
   end
+
+  context "when re-running with format_markdown: true on an already-annotated file" do
+    let(:options) { AnnotateRb::Options.from({format_markdown: true, force: true}) }
+
+    let(:schema_info) do
+      <<~SCHEMA
+        # ## Schema Information
+        #
+        # Table name: `users`
+        #
+        # ### Columns
+        #
+        # Name       | Type            | Attributes
+        # ---------- | --------------- | ---------------------------
+        # **`id`**   | `integer`       | `not null, primary key`
+        # **`name`** | `string(255)`   |
+        #
+        # ### Indexes
+        #
+        # * `index_users_on_name`:
+        #     * **`name`**
+        #
+      SCHEMA
+    end
+
+    let(:starting_file_content) do
+      <<~FILE
+        # frozen_string_literal: true
+        # ## Schema Information
+        #
+        # Table name: `users`
+        #
+        # ### Columns
+        #
+        # Name       | Type            | Attributes
+        # ---------- | --------------- | ---------------------------
+        # **`id`**   | `integer`       | `not null, primary key`
+        # **`name`** | `string(255)`   |
+        #
+        # ### Indexes
+        #
+        # * `index_users_on_name`:
+        #     * **`name`**
+        #
+
+        class User < ApplicationRecord
+        end
+      FILE
+    end
+
+    let(:expected_file_content) { starting_file_content }
+
+    include_examples "annotates the file"
+  end
 end

--- a/spec/lib/annotate_rb/model_annotator/file_parser/annotation_finder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/file_parser/annotation_finder_spec.rb
@@ -445,6 +445,140 @@ RSpec.describe AnnotateRb::ModelAnnotator::FileParser::AnnotationFinder do
       include_examples "finds and extracts the annotation"
     end
 
+    context "with a markdown-formatted annotation (format_markdown: true)" do
+      let(:content) do
+        <<~FILE
+          # ## Schema Information
+          #
+          # Table name: `users`
+          #
+          # ### Columns
+          #
+          # Name       | Type            | Attributes
+          # ---------- | --------------- | ---------------------------
+          # **`id`**   | `integer`       | `not null, primary key`
+          # **`name`** | `string(255)`   |
+          #
+          # ### Indexes
+          #
+          # * `index_users_on_name`:
+          #     * **`name`**
+          #
+          # ### Foreign Keys
+          #
+          # * `users_on_accounts`:
+          #     * **`account_id => accounts.id`**
+          #
+
+          class User < ApplicationRecord
+          end
+        FILE
+      end
+      let(:annotation_start) { 0 }
+      let(:annotation_end) { 20 }
+      let(:annotation) do
+        <<~ANNOTATION
+          # ## Schema Information
+          #
+          # Table name: `users`
+          #
+          # ### Columns
+          #
+          # Name       | Type            | Attributes
+          # ---------- | --------------- | ---------------------------
+          # **`id`**   | `integer`       | `not null, primary key`
+          # **`name`** | `string(255)`   |
+          #
+          # ### Indexes
+          #
+          # * `index_users_on_name`:
+          #     * **`name`**
+          #
+          # ### Foreign Keys
+          #
+          # * `users_on_accounts`:
+          #     * **`account_id => accounts.id`**
+          #
+        ANNOTATION
+      end
+
+      include_examples "finds and extracts the annotation"
+    end
+
+    context "with a markdown-formatted annotation followed by a user comment containing a single \"|\"" do
+      let(:content) do
+        <<~FILE
+          # ## Schema Information
+          #
+          # Table name: `users`
+          #
+          # ### Columns
+          #
+          # Name     | Type      | Attributes
+          # -------- | --------- | ---------------------------
+          # **`id`** | `integer` | `not null, primary key`
+          #
+          # See docs: foo | bar
+          class User < ApplicationRecord
+          end
+        FILE
+      end
+      let(:annotation_start) { 0 }
+      let(:annotation_end) { 9 }
+      let(:annotation) do
+        <<~ANNOTATION
+          # ## Schema Information
+          #
+          # Table name: `users`
+          #
+          # ### Columns
+          #
+          # Name     | Type      | Attributes
+          # -------- | --------- | ---------------------------
+          # **`id`** | `integer` | `not null, primary key`
+          #
+        ANNOTATION
+      end
+
+      include_examples "finds and extracts the annotation"
+    end
+
+    context "with a markdown-formatted annotation followed by a user comment starting with \"* \"" do
+      let(:content) do
+        <<~FILE
+          # ## Schema Information
+          #
+          # Table name: `users`
+          #
+          # ### Indexes
+          #
+          # * `index_users_on_name`:
+          #     * **`name`**
+          #
+          # * Remember to reindex nightly
+          class User < ApplicationRecord
+          end
+        FILE
+      end
+      let(:annotation_start) { 0 }
+      let(:annotation_end) { 8 }
+      let(:annotation) do
+        <<~ANNOTATION
+          # ## Schema Information
+          #
+          # Table name: `users`
+          #
+          # ### Indexes
+          #
+          # * `index_users_on_name`:
+          #     * **`name`**
+          #
+        ANNOTATION
+      end
+
+      include_examples "finds and extracts the annotation"
+    end
+
     context "with a yml file without annotations" do
       subject { described_class.new(content, wrapper_open, wrapper_close, yml_parser) }
 


### PR DESCRIPTION
## Problem

Since v4.23.0, re-running annotaterb with `format_markdown: true` on a file that is already correctly annotated duplicates the entire schema annotation block instead of leaving the file unchanged / replacing it in place.

Example (`Worker < User`, STI model, `format_markdown: true`):

```ruby
# ## Schema Information
#
# Table name: `users`
#
# ### Columns
#
# Name       | Type            | Attributes
# ---------- | --------------- | ---------------------------
# **`id`**   | `integer`       | `not null, primary key`
#
# ### Columns          <- duplicated block starts here
#
# Name       | Type            | Attributes
# ---------- | --------------- | ---------------------------
# **`id`**   | `integer`       | `not null, primary key`
#

require 'rails_helper'
```

Running annotaterb again on the already-duplicated file duplicates it a third time, and so on - it's not idempotent.

## Root cause

`AnnotationFinder#schema_like?` (added in #334) decides where an existing annotation block ends by walking forward from its start and checking whether each subsequent line "looks like" part of the schema:

```ruby
comment.match?(/\A#\s{2,}\S/)
```

This assumes at least two leading spaces after `#`, which holds for the default/plain format (`#  id  :integer  not null`) but not for `format_markdown: true`. Markdown-formatted section headers, table rows, and list items are all rendered with a single leading space after `#`:

- `# ### Columns` (section header)
- `` # **`id`** | `integer` | ... `` (table row)
- `` # * `index_name`: `` (foreign key/index/enum list item)

Because none of these match the two-space heuristic (and `SCHEMA_HEADER_EXACT` only matches the *plain* header text, not the `### `-prefixed markdown version), `walk_forward_through_schema` stops right after the very first line of the table (typically the header row). `annotation_end` is therefore computed far too early.

When `SingleFileAnnotator` re-runs on the file, `AnnotatedFile::Updater#update` only replaces this truncated region:

```ruby
@file_content.sub(@parsed_file.annotations) { new_annotation }
```

...leaving the rest of the old annotation (the actual column/index/foreign key rows) sitting in the file, immediately followed by the freshly generated one. Every subsequent run adds another copy.

This also affects `EnumAnnotation` (`# Enums`) in the **default** format, since `EnumAnnotation::Annotation::HEADER_TEXT` was never added to `SCHEMA_HEADER_EXACT` — likely an oversight from the same PR that introduced `show_enums`.

## Fix

- Added `EnumAnnotation::Annotation::HEADER_TEXT` (`"Enums"`) to `SCHEMA_HEADER_EXACT`, since it was missing alongside Indexes/Foreign Keys/Check Constraints.
- Added markdown-aware detection to `schema_like?`:
  - `### <name>` section headers, matched against known section names with the `### ` prefix stripped (`Columns` has no `HEADER_TEXT` constant since it's inlined in `Annotation::MarkdownHeader`, so it's listed explicitly).
  - Pipe-delimited table rows, requiring **two or more** `|` separators (not just one) so that a one-off user comment containing a stray `|` isn't mistaken for a table row.
  - Bulleted list items for foreign keys/indexes/enums (`` * `name`: `` / `` * **`col`** ``), requiring a backtick right after the bullet marker so an unrelated comment starting with `* ` isn't swallowed.

## Tests

- `annotation_finder_spec.rb`: boundary detection for a markdown-formatted annotation, plus two adversarial cases confirming a trailing user comment containing a single `|` or a plain `* ` bullet is **not** absorbed into the annotation.
- `annotating_a_file_with_comments_spec.rb`: end-to-end regression — running `SingleFileAnnotator` with `format_markdown: true` on an already-annotated file leaves it unchanged (previously it duplicated the block).

All existing specs pass (`851 examples, 0 failures` outside of `spec/integration`, which requires a full dummy Rails app/DB setup not available in this environment — verified those failures are identical with and without this change).

## Possible follow-up (not included in this PR)

`schema_like?` currently infers whether the file is markdown-formatted from the *shape* of each line (spacing, `###`, `|`, bullets). Since the caller (annotaterb itself) already knows the configured `format_markdown` option at
this point, an alternative design would be to pass that flag into `AnnotationFinder` and branch explicitly in `schema_like?`, rather than re-deriving it heuristically. That would avoid needing to keep `schema_like?` in sync with `Annotation::MarkdownHeader` / `ColumnComponent#to_markdown` / etc. every time the markdown output format
changes. Happy to follow up with that refactor in a separate PR if maintainers are interested — keeping this PR focused on the bug fix so it's easy to review and merge quickly.
