### PR TITLE
added :ignore_database_name option

### DIFF
--- a/lib/annotate_rb/model_annotator/annotation/schema_header.rb
+++ b/lib/annotate_rb/model_annotator/annotation/schema_header.rb
@@ -49,7 +49,7 @@ module AnnotateRb
           [
             Components::BlankCommentLine.new,
             TableName.new(name),
-            (DatabaseName.new(database_name) if database_name),
+            (DatabaseName.new(database_name) if show_database_name?),
             Components::BlankCommentLine.new
           ].compact
         end
@@ -66,6 +66,10 @@ module AnnotateRb
 
         def display_table_comments?
           @options[:with_comment] && @options[:with_table_comments]
+        end
+
+        def show_database_name?
+          database_name && !@options[:ignore_database_name]
         end
 
         def name

--- a/lib/annotate_rb/options.rb
+++ b/lib/annotate_rb/options.rb
@@ -42,6 +42,7 @@ module AnnotateRb
       format_yard: false, # ModelAnnotator
       frozen: false, # ModelAnnotator, but should be used by both
       grouped_polymorphic: false, # ModelAnnotator
+      ignore_database_name: false, # ModelAnnotator
       ignore_model_sub_dir: false, # ModelAnnotator
       ignore_unknown_models: false, # ModelAnnotator
       include_version: false, # ModelAnnotator
@@ -118,6 +119,7 @@ module AnnotateRb
       :format_yard,
       :frozen,
       :grouped_polymorphic,
+      :ignore_database_name,
       :ignore_model_sub_dir,
       :ignore_unknown_models,
       :include_version,

--- a/lib/annotate_rb/parser.rb
+++ b/lib/annotate_rb/parser.rb
@@ -222,6 +222,11 @@ module AnnotateRb
         @options[:ignore_unknown_models] = true
       end
 
+      option_parser.on("--ignore-database-name",
+        "don't include the database name in the annotation") do
+        @options[:ignore_database_name] = true
+      end
+
       option_parser.on("-I",
         "--ignore-columns REGEX",
         "don't annotate columns that match a given REGEX (i.e., `annotate -I '^(id|updated_at|created_at)'`") do |regex|

--- a/spec/lib/annotate_rb/model_annotator/annotation/schema_header_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/annotation/schema_header_spec.rb
@@ -34,6 +34,24 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotation::SchemaHeader do
       end
 
       it { is_expected.to eq(expected_header) }
+
+      context "with `ignore_database_name: true`" do
+        let :options do
+          AnnotateRb::Options.new({ignore_database_name: true})
+        end
+
+        let(:expected_header) do
+          <<~HEADER.strip
+            #
+            # Table name: users
+            #
+          HEADER
+        end
+
+        it "returns the header without the database name" do
+          is_expected.to eq(expected_header)
+        end
+      end
     end
 
     context "with `with_comment: true`" do


### PR DESCRIPTION
when enabled, it won't write the database name to the annotatino block

this option may be confusing in a sharded database scenario, where the development name just does not map to reality