### PR TITLE
Move ignore_database_name check into AnnotationBuilder

### DIFF
--- a/lib/annotate_rb/model_annotator/annotation/annotation_builder.rb
+++ b/lib/annotate_rb/model_annotator/annotation/annotation_builder.rb
@@ -65,7 +65,7 @@ module AnnotateRb
           table_name = @model.table_name
           table_comment = @model.connection.try(:table_comment, @model.table_name)
           max_size = @model.max_schema_info_width
-          database_name = @model.database_name if multi_db_environment?
+          database_name = @model.database_name if show_database_name?
 
           _annotation = Annotation.new(@options,
             version: version, table_name: table_name, table_comment: table_comment,
@@ -73,6 +73,11 @@ module AnnotateRb
         end
 
         private
+
+        # TODO: Consolidate ignore_database_name and ignore_multi_database_name; they serve the same purpose
+        def show_database_name?
+          !@options[:ignore_database_name] && multi_db_environment?
+        end
 
         def multi_db_environment?
           return false if @options[:ignore_multi_database_name]

--- a/lib/annotate_rb/model_annotator/annotation/schema_header.rb
+++ b/lib/annotate_rb/model_annotator/annotation/schema_header.rb
@@ -49,7 +49,7 @@ module AnnotateRb
           [
             Components::BlankCommentLine.new,
             TableName.new(name),
-            (DatabaseName.new(database_name) if show_database_name?),
+            (DatabaseName.new(database_name) if database_name),
             Components::BlankCommentLine.new
           ].compact
         end
@@ -66,10 +66,6 @@ module AnnotateRb
 
         def display_table_comments?
           @options[:with_comment] && @options[:with_table_comments]
-        end
-
-        def show_database_name?
-          database_name && !@options[:ignore_database_name]
         end
 
         def name

--- a/spec/integration/annotate_models_in_multi_db_spec.rb
+++ b/spec/integration/annotate_models_in_multi_db_spec.rb
@@ -54,4 +54,22 @@ RSpec.describe "Annotate models in a multi-db environment with duplicate table n
     expect(primary_content).not_to include("# Database name: primary")
     expect(secondary_content).not_to include("# Database name: secondary")
   end
+
+  it "does not include the database name when ignore_database_name is true" do
+    reset_database
+    run_migrations
+
+    config_content = <<~YAML.strip
+      ignore_database_name: true
+    YAML
+    write_file(".annotaterb.yml", config_content)
+
+    run_command_and_stop("bundle exec annotaterb models", fail_on_error: true, exit_timeout: command_timeout_seconds)
+
+    primary_content = read_file(dummyapp_model("test_default.rb"))
+    secondary_content = read_file(dummyapp_model("secondary/test_default.rb"))
+
+    expect(primary_content).not_to include("# Database name: primary")
+    expect(secondary_content).not_to include("# Database name: secondary")
+  end
 end

--- a/spec/lib/annotate_rb/model_annotator/annotation/schema_header_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/annotation/schema_header_spec.rb
@@ -34,24 +34,6 @@ RSpec.describe AnnotateRb::ModelAnnotator::Annotation::SchemaHeader do
       end
 
       it { is_expected.to eq(expected_header) }
-
-      context "with `ignore_database_name: true`" do
-        let :options do
-          AnnotateRb::Options.new({ignore_database_name: true})
-        end
-
-        let(:expected_header) do
-          <<~HEADER.strip
-            #
-            # Table name: users
-            #
-          HEADER
-        end
-
-        it "returns the header without the database name" do
-          is_expected.to eq(expected_header)
-        end
-      end
     end
 
     context "with `with_comment: true`" do


### PR DESCRIPTION
SchemaHeader was deciding whether to render a database name that AnnotationBuilder had already resolved. 
When `ignore_database_name` is set, skip resolving it in the builder instead of fetching it and then hiding it at display time.