### PR TITLE
Remove empty TODO comment from Runner

### DIFF
--- a/lib/annotate_rb/runner.rb
+++ b/lib/annotate_rb/runner.rb
@@ -46,8 +46,6 @@ module AnnotateRb
       raise "Didn't specify a command" unless @options[:command]
 
       @options[:command].call(@options)
-
-      # TODO
     end
   end
 end


### PR DESCRIPTION
The trailing TODO had no description or planned follow-up, so I removed it.