### PR TITLE
Fix NoMethodError when handling malformed annotations

### DIFF
--- a/lib/annotate_rb/model_annotator/single_file_annotation_remover.rb
+++ b/lib/annotate_rb/model_annotator/single_file_annotation_remover.rb
@@ -18,7 +18,7 @@ module AnnotateRb
             parsed_file = FileParser::ParsedFile.new(old_content, "", parser_klass, options).parse
           rescue FileParser::AnnotationFinder::MalformedAnnotation => e
             warn "Unable to process #{file_name}: #{e.message}"
-            warn "\t" + e.backtrace.join("\n\t") if @options[:trace]
+            warn "\t" + e.backtrace.join("\n\t") if options[:trace]
             return false
           end
 

--- a/lib/annotate_rb/model_annotator/single_file_annotator.rb
+++ b/lib/annotate_rb/model_annotator/single_file_annotator.rb
@@ -31,7 +31,7 @@ module AnnotateRb
             parsed_file = FileParser::ParsedFile.new(old_content, annotation, parser_klass, options, model_class_name: model_class_name).parse
           rescue FileParser::AnnotationFinder::MalformedAnnotation => e
             warn "Unable to process #{file_name}: #{e.message}"
-            warn "\t" + e.backtrace.join("\n\t") if @options[:trace]
+            warn "\t" + e.backtrace.join("\n\t") if options[:trace]
             return false
           end
 

--- a/spec/lib/annotate_rb/model_annotator/single_file_annotation_remover_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/single_file_annotation_remover_spec.rb
@@ -203,5 +203,21 @@ RSpec.describe AnnotateRb::ModelAnnotator::SingleFileAnnotationRemover do
         expect(file_content_after_removal).to eq expected_result
       end
     end
+
+    context "when the file has a malformed annotation" do
+      let(:file_content) do
+        <<~EOS
+          # == Schema Info
+          class Foo < ActiveRecord::Base
+          end
+        EOS
+      end
+
+      it "returns false without raising" do
+        expect {
+          expect(described_class.call(path, AnnotateRb::Options.new({}))).to be(false)
+        }.to output(/Unable to process/).to_stderr
+      end
+    end
   end
 end

--- a/spec/lib/annotate_rb/model_annotator/single_file_annotator_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/single_file_annotator_spec.rb
@@ -475,5 +475,22 @@ RSpec.describe AnnotateRb::ModelAnnotator::SingleFileAnnotator do
         expect(File.read(@model_file_name)).to eq(expected_file_content)
       end
     end
+
+    context "when the file has a malformed annotation" do
+      before do
+        @model_dir = Dir.mktmpdir("annotaterb")
+        (@model_file_name, _file_content) = write_model("user.rb", <<~FILE)
+          # == Schema Info
+          class User < ApplicationRecord
+          end
+        FILE
+      end
+
+      it "returns false without raising" do
+        expect {
+          expect(described_class.call(@model_file_name, "", :position_in_class, AnnotateRb::Options.new({}))).to be(false)
+        }.to output(/Unable to process/).to_stderr
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem
`annotaterb models` crashed when a model file had a schema annotation header without a contiguous annotation body. For example:

```rb
# == Schema Info
class User < ApplicationRecord
end
```

AnnotationFinder raises MalformedAnnotation when it finds ` == Schema Info` / `## Schema Info` but the contiguous comment block is only one line. The rescue then crashed:

```sh
Unable to process app/models/user.rb: ...MalformedAnnotation
bundler: failed to load command: annotaterb (...)

.../single_file_annotator.rb:34:in `rescue in call':
  undefined method `[]' for nil:NilClass (NoMethodError)

    warn "\t" + e.backtrace.join("\n\t") if @options[:trace]
```

## Cause
SingleFileAnnotator and SingleFileAnnotationRemover are class methods, so `@options` is never set. The MalformedAnnotation rescue accessed `@options[:trace]` and raised `NoMethodError` after the intended warning.

--delete hid the same bug: `ProjectAnnotationRemover` rescues the secondary `NoMethodError`, so the process continued with a second "Unable to process" warning instead of aborting.

## Fix
Use the `options` argument at both call sites so malformed annotations are skipped cleanly.