### PR TITLE
Fix `--without-comment` help text to say exclude

### DIFF
--- a/lib/annotate_rb/parser.rb
+++ b/lib/annotate_rb/parser.rb
@@ -239,7 +239,7 @@ module AnnotateRb
       end
 
       option_parser.on("--without-comment",
-        "include database comments in model annotations") do
+        "exclude database comments in model annotations") do
         @options[:with_comment] = false
       end
 


### PR DESCRIPTION
The flag sets with_comment to false, but its `OptionParser` description still said `include` matching `--with-comment`. Align the help with the behavior and README.