### PR TITLE
Annotate PostgreSQL unique and exclusion constraints

### DIFF
--- a/lib/annotate_rb/model_annotator.rb
+++ b/lib/annotate_rb/model_annotator.rb
@@ -27,6 +27,8 @@ module AnnotateRb
     autoload :FileParser, "annotate_rb/model_annotator/file_parser"
     autoload :ZeitwerkClassGetter, "annotate_rb/model_annotator/zeitwerk_class_getter"
     autoload :CheckConstraintAnnotation, "annotate_rb/model_annotator/check_constraint_annotation"
+    autoload :UniqueConstraintAnnotation, "annotate_rb/model_annotator/unique_constraint_annotation"
+    autoload :ExclusionConstraintAnnotation, "annotate_rb/model_annotator/exclusion_constraint_annotation"
     autoload :EnumAnnotation, "annotate_rb/model_annotator/enum_annotation"
     autoload :FileToParserMapper, "annotate_rb/model_annotator/file_to_parser_mapper"
     autoload :Components, "annotate_rb/model_annotator/components"

--- a/lib/annotate_rb/model_annotator/annotation/annotation_builder.rb
+++ b/lib/annotate_rb/model_annotator/annotation/annotation_builder.rb
@@ -27,6 +27,8 @@ module AnnotateRb
               IndexAnnotation::AnnotationBuilder.new(@model, @options).build,
               ForeignKeyAnnotation::AnnotationBuilder.new(@model, @options).build,
               CheckConstraintAnnotation::AnnotationBuilder.new(@model, @options).build,
+              UniqueConstraintAnnotation::AnnotationBuilder.new(@model, @options).build,
+              ExclusionConstraintAnnotation::AnnotationBuilder.new(@model, @options).build,
               EnumAnnotation::AnnotationBuilder.new(@model, @options).build,
               SchemaFooter.new
             ]

--- a/lib/annotate_rb/model_annotator/exclusion_constraint_annotation.rb
+++ b/lib/annotate_rb/model_annotator/exclusion_constraint_annotation.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module AnnotateRb
+  module ModelAnnotator
+    module ExclusionConstraintAnnotation
+      autoload :AnnotationBuilder, "annotate_rb/model_annotator/exclusion_constraint_annotation/annotation_builder"
+      autoload :Annotation, "annotate_rb/model_annotator/exclusion_constraint_annotation/annotation"
+      autoload :ExclusionConstraintComponent, "annotate_rb/model_annotator/exclusion_constraint_annotation/exclusion_constraint_component"
+    end
+  end
+end

--- a/lib/annotate_rb/model_annotator/exclusion_constraint_annotation/annotation.rb
+++ b/lib/annotate_rb/model_annotator/exclusion_constraint_annotation/annotation.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module AnnotateRb
+  module ModelAnnotator
+    module ExclusionConstraintAnnotation
+      class Annotation
+        HEADER_TEXT = "Exclusion Constraints"
+
+        def initialize(constraints)
+          @constraints = constraints
+        end
+
+        def body
+          [
+            Components::BlankCommentLine.new,
+            Components::Header.new(HEADER_TEXT),
+            Components::BlankCommentLine.new,
+            *@constraints
+          ]
+        end
+
+        def to_markdown
+          body.map(&:to_markdown).join("\n")
+        end
+
+        def to_rdoc
+          body.map(&:to_rdoc).join("\n")
+        end
+
+        def to_yard
+          body.map(&:to_yard).join("\n")
+        end
+
+        def to_default
+          body.map(&:to_default).join("\n")
+        end
+      end
+    end
+  end
+end

--- a/lib/annotate_rb/model_annotator/exclusion_constraint_annotation/annotation_builder.rb
+++ b/lib/annotate_rb/model_annotator/exclusion_constraint_annotation/annotation_builder.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module AnnotateRb
+  module ModelAnnotator
+    module ExclusionConstraintAnnotation
+      class AnnotationBuilder
+        def initialize(model, options)
+          @model = model
+          @options = options
+        end
+
+        def build
+          return Components::NilComponent.new if !@options[:show_exclusion_constraints]
+          return Components::NilComponent.new unless @model.connection.respond_to?(:supports_exclusion_constraints?) &&
+            @model.connection.supports_exclusion_constraints? && @model.connection.respond_to?(:exclusion_constraints)
+
+          exclusion_constraints = @model.connection.exclusion_constraints(@model.table_name)
+          return Components::NilComponent.new if exclusion_constraints.empty?
+
+          max_size = exclusion_constraints.map { |exclusion_constraint| exclusion_constraint.name.size }.max + 1
+
+          constraints = exclusion_constraints.sort_by(&:name).map do |exclusion_constraint|
+            details = "(#{exclusion_constraint.expression})"
+            details += " USING #{exclusion_constraint.using}" if exclusion_constraint.using
+            details += " WHERE (#{exclusion_constraint.where})" if exclusion_constraint.where
+            if exclusion_constraint.deferrable
+              initially = (exclusion_constraint.deferrable == true) ? "IMMEDIATE" : exclusion_constraint.deferrable.to_s.upcase
+              details += " DEFERRABLE INITIALLY #{initially}"
+            end
+
+            ExclusionConstraintComponent.new(exclusion_constraint.name, details, max_size)
+          end
+
+          _annotation = Annotation.new(constraints)
+        end
+      end
+    end
+  end
+end

--- a/lib/annotate_rb/model_annotator/exclusion_constraint_annotation/annotation_builder.rb
+++ b/lib/annotate_rb/model_annotator/exclusion_constraint_annotation/annotation_builder.rb
@@ -24,8 +24,7 @@ module AnnotateRb
             details += " USING #{exclusion_constraint.using}" if exclusion_constraint.using
             details += " WHERE (#{exclusion_constraint.where})" if exclusion_constraint.where
             if exclusion_constraint.deferrable
-              initially = (exclusion_constraint.deferrable == true) ? "IMMEDIATE" : exclusion_constraint.deferrable.to_s.upcase
-              details += " DEFERRABLE INITIALLY #{initially}"
+              details += " DEFERRABLE INITIALLY #{exclusion_constraint.deferrable.to_s.upcase}"
             end
 
             ExclusionConstraintComponent.new(exclusion_constraint.name, details, max_size)

--- a/lib/annotate_rb/model_annotator/exclusion_constraint_annotation/exclusion_constraint_component.rb
+++ b/lib/annotate_rb/model_annotator/exclusion_constraint_annotation/exclusion_constraint_component.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module AnnotateRb
+  module ModelAnnotator
+    module ExclusionConstraintAnnotation
+      class ExclusionConstraintComponent < Components::Base
+        attr_reader :name, :details, :max_size
+
+        def initialize(name, details, max_size)
+          @name = name
+          @details = details
+          @max_size = max_size
+        end
+
+        def to_default
+          # standard:disable Lint/FormatParameterMismatch
+          sprintf("#  %-#{max_size}.#{max_size}s %s", name, details).rstrip
+          # standard:enable Lint/FormatParameterMismatch
+        end
+
+        def to_markdown
+          sprintf("# * `%s`: `%s`", name, details)
+        end
+      end
+    end
+  end
+end

--- a/lib/annotate_rb/model_annotator/file_parser/annotation_finder.rb
+++ b/lib/annotate_rb/model_annotator/file_parser/annotation_finder.rb
@@ -20,6 +20,8 @@ module AnnotateRb
           IndexAnnotation::Annotation::HEADER_TEXT,
           ForeignKeyAnnotation::Annotation::HEADER_TEXT,
           CheckConstraintAnnotation::Annotation::HEADER_TEXT,
+          UniqueConstraintAnnotation::Annotation::HEADER_TEXT,
+          ExclusionConstraintAnnotation::Annotation::HEADER_TEXT,
           EnumAnnotation::Annotation::HEADER_TEXT
         ].freeze
 

--- a/lib/annotate_rb/model_annotator/index_annotation/annotation_builder.rb
+++ b/lib/annotate_rb/model_annotator/index_annotation/annotation_builder.rb
@@ -15,6 +15,9 @@ module AnnotateRb
           indexes = @model.retrieve_indexes_from_table
           return Components::NilComponent.new if indexes.empty?
 
+          indexes = reject_constraint_backed_indexes(indexes)
+          return Components::NilComponent.new if indexes.empty?
+
           max_size = indexes.map { |index| index.name.size }.max + 1
 
           indexes = indexes.sort_by(&:name).map do |index|
@@ -22,6 +25,32 @@ module AnnotateRb
           end
 
           _annotation = Annotation.new(indexes)
+        end
+
+        private
+
+        # Mirrors ActiveRecord's schema_dumper#indexes_in_create: PostgreSQL's
+        # unique and exclusion constraints are backed by indexes with the same
+        # name, so those show up in `connection.indexes` too. Drop them here so
+        # they only appear under their dedicated sections.
+        def reject_constraint_backed_indexes(indexes)
+          connection = @model.connection
+
+          if connection.respond_to?(:supports_exclusion_constraints?) &&
+              connection.supports_exclusion_constraints? &&
+              connection.respond_to?(:exclusion_constraints)
+            excl_names = connection.exclusion_constraints(@model.table_name).map(&:name)
+            indexes = indexes.reject { |index| excl_names.include?(index.name) }
+          end
+
+          if connection.respond_to?(:supports_unique_constraints?) &&
+              connection.supports_unique_constraints? &&
+              connection.respond_to?(:unique_constraints)
+            unique_names = connection.unique_constraints(@model.table_name).map(&:name)
+            indexes = indexes.reject { |index| unique_names.include?(index.name) }
+          end
+
+          indexes
         end
       end
     end

--- a/lib/annotate_rb/model_annotator/unique_constraint_annotation.rb
+++ b/lib/annotate_rb/model_annotator/unique_constraint_annotation.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module AnnotateRb
+  module ModelAnnotator
+    module UniqueConstraintAnnotation
+      autoload :AnnotationBuilder, "annotate_rb/model_annotator/unique_constraint_annotation/annotation_builder"
+      autoload :Annotation, "annotate_rb/model_annotator/unique_constraint_annotation/annotation"
+      autoload :UniqueConstraintComponent, "annotate_rb/model_annotator/unique_constraint_annotation/unique_constraint_component"
+    end
+  end
+end

--- a/lib/annotate_rb/model_annotator/unique_constraint_annotation/annotation.rb
+++ b/lib/annotate_rb/model_annotator/unique_constraint_annotation/annotation.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module AnnotateRb
+  module ModelAnnotator
+    module UniqueConstraintAnnotation
+      class Annotation
+        HEADER_TEXT = "Unique Constraints"
+
+        def initialize(constraints)
+          @constraints = constraints
+        end
+
+        def body
+          [
+            Components::BlankCommentLine.new,
+            Components::Header.new(HEADER_TEXT),
+            Components::BlankCommentLine.new,
+            *@constraints
+          ]
+        end
+
+        def to_markdown
+          body.map(&:to_markdown).join("\n")
+        end
+
+        def to_rdoc
+          body.map(&:to_rdoc).join("\n")
+        end
+
+        def to_yard
+          body.map(&:to_yard).join("\n")
+        end
+
+        def to_default
+          body.map(&:to_default).join("\n")
+        end
+      end
+    end
+  end
+end

--- a/lib/annotate_rb/model_annotator/unique_constraint_annotation/annotation_builder.rb
+++ b/lib/annotate_rb/model_annotator/unique_constraint_annotation/annotation_builder.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module AnnotateRb
+  module ModelAnnotator
+    module UniqueConstraintAnnotation
+      class AnnotationBuilder
+        def initialize(model, options)
+          @model = model
+          @options = options
+        end
+
+        def build
+          return Components::NilComponent.new if !@options[:show_unique_constraints]
+          return Components::NilComponent.new unless @model.connection.respond_to?(:supports_unique_constraints?) &&
+            @model.connection.supports_unique_constraints? && @model.connection.respond_to?(:unique_constraints)
+
+          unique_constraints = @model.connection.unique_constraints(@model.table_name)
+          return Components::NilComponent.new if unique_constraints.empty?
+
+          max_size = unique_constraints.map { |unique_constraint| unique_constraint.name.size }.max + 1
+
+          constraints = unique_constraints.sort_by(&:name).map do |unique_constraint|
+            columns = Array(unique_constraint.column)
+            details = "(#{columns.join(", ")})"
+            if unique_constraint.deferrable
+              initially = (unique_constraint.deferrable == true) ? "IMMEDIATE" : unique_constraint.deferrable.to_s.upcase
+              details += " DEFERRABLE INITIALLY #{initially}"
+            end
+
+            UniqueConstraintComponent.new(unique_constraint.name, details, max_size)
+          end
+
+          _annotation = Annotation.new(constraints)
+        end
+      end
+    end
+  end
+end

--- a/lib/annotate_rb/model_annotator/unique_constraint_annotation/annotation_builder.rb
+++ b/lib/annotate_rb/model_annotator/unique_constraint_annotation/annotation_builder.rb
@@ -23,8 +23,7 @@ module AnnotateRb
             columns = Array(unique_constraint.column)
             details = "(#{columns.join(", ")})"
             if unique_constraint.deferrable
-              initially = (unique_constraint.deferrable == true) ? "IMMEDIATE" : unique_constraint.deferrable.to_s.upcase
-              details += " DEFERRABLE INITIALLY #{initially}"
+              details += " DEFERRABLE INITIALLY #{unique_constraint.deferrable.to_s.upcase}"
             end
 
             UniqueConstraintComponent.new(unique_constraint.name, details, max_size)

--- a/lib/annotate_rb/model_annotator/unique_constraint_annotation/unique_constraint_component.rb
+++ b/lib/annotate_rb/model_annotator/unique_constraint_annotation/unique_constraint_component.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module AnnotateRb
+  module ModelAnnotator
+    module UniqueConstraintAnnotation
+      class UniqueConstraintComponent < Components::Base
+        attr_reader :name, :details, :max_size
+
+        def initialize(name, details, max_size)
+          @name = name
+          @details = details
+          @max_size = max_size
+        end
+
+        def to_default
+          # standard:disable Lint/FormatParameterMismatch
+          sprintf("#  %-#{max_size}.#{max_size}s %s", name, details).rstrip
+          # standard:enable Lint/FormatParameterMismatch
+        end
+
+        def to_markdown
+          sprintf("# * `%s`: `%s`", name, details)
+        end
+      end
+    end
+  end
+end

--- a/lib/annotate_rb/options.rb
+++ b/lib/annotate_rb/options.rb
@@ -48,6 +48,8 @@ module AnnotateRb
       include_version: false, # ModelAnnotator
       show_complete_foreign_keys: false, # ModelAnnotator
       show_check_constraints: false, # ModelAnnotator
+      show_unique_constraints: false, # ModelAnnotator
+      show_exclusion_constraints: false, # ModelAnnotator
       show_enums: false, # ModelAnnotator
       show_foreign_keys: true, # ModelAnnotator
       show_indexes: true, # ModelAnnotator
@@ -124,6 +126,8 @@ module AnnotateRb
       :ignore_unknown_models,
       :include_version,
       :show_check_constraints,
+      :show_unique_constraints,
+      :show_exclusion_constraints,
       :show_enums,
       :show_complete_foreign_keys,
       :show_foreign_keys,

--- a/lib/annotate_rb/parser.rb
+++ b/lib/annotate_rb/parser.rb
@@ -207,6 +207,16 @@ module AnnotateRb
         @options[:show_check_constraints] = true
       end
 
+      option_parser.on("--show-unique-constraints",
+        "List the table's unique constraints in the annotation") do
+        @options[:show_unique_constraints] = true
+      end
+
+      option_parser.on("--show-exclusion-constraints",
+        "List the table's exclusion constraints in the annotation") do
+        @options[:show_exclusion_constraints] = true
+      end
+
       option_parser.on("--hide-limit-column-types VALUES",
         "don't show limit for given column types, separated by commas (i.e., `integer,boolean,text`)") do |values|
         @options[:hide_limit_column_types] = values.to_s

--- a/spec/lib/annotate_rb/model_annotator/exclusion_constraint_annotation/annotation_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/exclusion_constraint_annotation/annotation_builder_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+RSpec.describe AnnotateRb::ModelAnnotator::ExclusionConstraintAnnotation::AnnotationBuilder do
+  include AnnotateTestHelpers
+
+  describe "#build" do
+    subject { described_class.new(model, options).build }
+    let(:default_format) { subject.to_default }
+    let(:markdown_format) { subject.to_markdown }
+    let(:yard_format) { subject.to_yard }
+    let(:rdoc_format) { subject.to_rdoc }
+
+    let(:model) do
+      instance_double(
+        AnnotateRb::ModelAnnotator::ModelWrapper,
+        connection: connection,
+        table_name: "Foo"
+      )
+    end
+    let(:connection) do
+      mock_connection([], [], [], exclusion_constraints: exclusion_constraints)
+    end
+    let(:options) { AnnotateRb::Options.new({show_exclusion_constraints: true}) }
+    let(:exclusion_constraints) do
+      [
+        mock_exclusion_constraint("no_overlap", "room_id WITH =, during WITH &&",
+          using: :gist,
+          where: "canceled = false",
+          deferrable: :deferred),
+        mock_exclusion_constraint("exclude_period", "period WITH &&", using: :gist),
+        mock_exclusion_constraint("plain_exclude", "id WITH =")
+      ]
+    end
+
+    context "when show_exclusion_constraints option is false" do
+      let(:options) { AnnotateRb::Options.new({show_exclusion_constraints: false}) }
+
+      it { is_expected.to be_a(AnnotateRb::ModelAnnotator::Components::NilComponent) }
+    end
+
+    context "using default format" do
+      let(:expected_result) do
+        <<~RESULT.strip
+          #
+          # Exclusion Constraints
+          #
+          #  exclude_period  (period WITH &&) USING gist
+          #  no_overlap      (room_id WITH =, during WITH &&) USING gist WHERE (canceled = false) DEFERRABLE INITIALLY DEFERRED
+          #  plain_exclude   (id WITH =)
+        RESULT
+      end
+
+      it "annotates the exclusion constraints" do
+        expect(default_format).to eq(expected_result)
+      end
+    end
+
+    context "using markdown format" do
+      let(:expected_result) do
+        <<~RESULT.strip
+          #
+          # ### Exclusion Constraints
+          #
+          # * `exclude_period`: `(period WITH &&) USING gist`
+          # * `no_overlap`: `(room_id WITH =, during WITH &&) USING gist WHERE (canceled = false) DEFERRABLE INITIALLY DEFERRED`
+          # * `plain_exclude`: `(id WITH =)`
+        RESULT
+      end
+
+      it "annotates the exclusion constraints" do
+        expect(markdown_format).to eq(expected_result)
+      end
+    end
+
+    context "when model connection does not support exclusion constraints" do
+      let(:connection) do
+        mock_connection([], [], [], supports_exclusion_constraints?: false, exclusion_constraints: exclusion_constraints)
+      end
+
+      it { expect(default_format).to be_nil }
+    end
+
+    context "when exclusion constraints is empty" do
+      let(:connection) do
+        mock_connection([], [], [], exclusion_constraints: [])
+      end
+
+      it { expect(default_format).to be_nil }
+    end
+
+    context "using yard format" do
+      let(:expected_result) do
+        <<~RESULT.strip
+          #
+          # Exclusion Constraints
+          #
+          #  exclude_period  (period WITH &&) USING gist
+          #  no_overlap      (room_id WITH =, during WITH &&) USING gist WHERE (canceled = false) DEFERRABLE INITIALLY DEFERRED
+          #  plain_exclude   (id WITH =)
+        RESULT
+      end
+
+      it "annotates the exclusion constraints" do
+        expect(yard_format).to eq(expected_result)
+      end
+    end
+
+    context "using rdoc format" do
+      let(:expected_result) do
+        <<~RESULT.strip
+          #
+          # Exclusion Constraints
+          #
+          #  exclude_period  (period WITH &&) USING gist
+          #  no_overlap      (room_id WITH =, during WITH &&) USING gist WHERE (canceled = false) DEFERRABLE INITIALLY DEFERRED
+          #  plain_exclude   (id WITH =)
+        RESULT
+      end
+
+      it "annotates the exclusion constraints" do
+        expect(rdoc_format).to eq(expected_result)
+      end
+    end
+  end
+end

--- a/spec/lib/annotate_rb/model_annotator/index_annotation/annotation_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/index_annotation/annotation_builder_spec.rb
@@ -260,6 +260,51 @@ RSpec.describe AnnotateRb::ModelAnnotator::IndexAnnotation::AnnotationBuilder do
       end
     end
 
+    context "when indexes back a unique or exclusion constraint" do
+      let(:indexes) do
+        [
+          mock_index("plain_index", columns: ["id"]),
+          mock_index("unique_email", columns: ["email"], unique: true),
+          mock_index("no_overlap", columns: ["room_id", "during"], using: "gist")
+        ]
+      end
+      let(:unique_constraints) { [mock_unique_constraint("unique_email", ["email"])] }
+      let(:exclusion_constraints) { [mock_exclusion_constraint("no_overlap", "room_id WITH =, during WITH &&", using: :gist)] }
+
+      let(:model) do
+        connection = mock_connection(indexes, [], [],
+          unique_constraints: unique_constraints,
+          exclusion_constraints: exclusion_constraints)
+
+        klass = mock_class_with_custom_connection(:reservations, nil, [], connection)
+        ::AnnotateRb::ModelAnnotator::ModelWrapper.new(klass, options)
+      end
+
+      let(:expected_result) do
+        <<~EOS.strip
+          #
+          # Indexes
+          #
+          #  plain_index  (id)
+        EOS
+      end
+
+      it "excludes the constraint-backed indexes from the Indexes section" do
+        expect(default_format).to eq(expected_result)
+      end
+
+      context "when only constraint-backed indexes exist" do
+        let(:indexes) do
+          [
+            mock_index("unique_email", columns: ["email"], unique: true),
+            mock_index("no_overlap", columns: ["room_id", "during"], using: "gist")
+          ]
+        end
+
+        it { is_expected.to be_a(AnnotateRb::ModelAnnotator::Components::NilComponent) }
+      end
+    end
+
     describe "#to_yard" do
       let(:indexes) do
         [mock_index("index_rails_02e851e3b7", columns: ["id"])]

--- a/spec/lib/annotate_rb/model_annotator/unique_constraint_annotation/annotation_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/unique_constraint_annotation/annotation_builder_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+RSpec.describe AnnotateRb::ModelAnnotator::UniqueConstraintAnnotation::AnnotationBuilder do
+  include AnnotateTestHelpers
+
+  describe "#build" do
+    subject { described_class.new(model, options).build }
+    let(:default_format) { subject.to_default }
+    let(:markdown_format) { subject.to_markdown }
+    let(:yard_format) { subject.to_yard }
+    let(:rdoc_format) { subject.to_rdoc }
+
+    let(:model) do
+      instance_double(
+        AnnotateRb::ModelAnnotator::ModelWrapper,
+        connection: connection,
+        table_name: "Foo"
+      )
+    end
+    let(:connection) do
+      mock_connection([], [], [], unique_constraints: unique_constraints)
+    end
+    let(:options) { AnnotateRb::Options.new({show_unique_constraints: true}) }
+    let(:unique_constraints) do
+      [
+        mock_unique_constraint("unique_position", ["position"]),
+        mock_unique_constraint("unique_sku", ["tenant_id", "sku"]),
+        mock_unique_constraint("unique_deferred", ["email"], deferrable: :deferred)
+      ]
+    end
+
+    context "when show_unique_constraints option is false" do
+      let(:options) { AnnotateRb::Options.new({show_unique_constraints: false}) }
+
+      it { is_expected.to be_a(AnnotateRb::ModelAnnotator::Components::NilComponent) }
+    end
+
+    context "using default format" do
+      let(:expected_result) do
+        <<~RESULT.strip
+          #
+          # Unique Constraints
+          #
+          #  unique_deferred  (email) DEFERRABLE INITIALLY DEFERRED
+          #  unique_position  (position)
+          #  unique_sku       (tenant_id, sku)
+        RESULT
+      end
+
+      it "annotates the unique constraints" do
+        expect(default_format).to eq(expected_result)
+      end
+    end
+
+    context "using markdown format" do
+      let(:expected_result) do
+        <<~RESULT.strip
+          #
+          # ### Unique Constraints
+          #
+          # * `unique_deferred`: `(email) DEFERRABLE INITIALLY DEFERRED`
+          # * `unique_position`: `(position)`
+          # * `unique_sku`: `(tenant_id, sku)`
+        RESULT
+      end
+
+      it "annotates the unique constraints" do
+        expect(markdown_format).to eq(expected_result)
+      end
+    end
+
+    context "when model connection does not support unique constraints" do
+      let(:connection) do
+        mock_connection([], [], [], supports_unique_constraints?: false, unique_constraints: unique_constraints)
+      end
+
+      it { expect(default_format).to be_nil }
+    end
+
+    context "when unique constraints is empty" do
+      let(:connection) do
+        mock_connection([], [], [], unique_constraints: [])
+      end
+
+      it { expect(default_format).to be_nil }
+    end
+
+    context "using yard format" do
+      let(:expected_result) do
+        <<~RESULT.strip
+          #
+          # Unique Constraints
+          #
+          #  unique_deferred  (email) DEFERRABLE INITIALLY DEFERRED
+          #  unique_position  (position)
+          #  unique_sku       (tenant_id, sku)
+        RESULT
+      end
+
+      it "annotates the unique constraints" do
+        expect(yard_format).to eq(expected_result)
+      end
+    end
+
+    context "using rdoc format" do
+      let(:expected_result) do
+        <<~RESULT.strip
+          #
+          # Unique Constraints
+          #
+          #  unique_deferred  (email) DEFERRABLE INITIALLY DEFERRED
+          #  unique_position  (position)
+          #  unique_sku       (tenant_id, sku)
+        RESULT
+      end
+
+      it "annotates the unique constraints" do
+        expect(rdoc_format).to eq(expected_result)
+      end
+    end
+  end
+end

--- a/spec/support/annotate_test_helpers.rb
+++ b/spec/support/annotate_test_helpers.rb
@@ -46,8 +46,12 @@ module AnnotateTestHelpers
       indexes: indexes,
       check_constraints: check_constraints,
       foreign_keys: foreign_keys,
+      unique_constraints: [],
+      exclusion_constraints: [],
       supports_foreign_keys?: true,
       supports_check_constraints?: true,
+      supports_unique_constraints?: true,
+      supports_exclusion_constraints?: true,
       lookup_cast_type_from_column: identity_type
     }.merge(options)
 
@@ -117,5 +121,21 @@ module AnnotateTestHelpers
       name: name,
       expression: expression,
       validated?: validated)
+  end
+
+  def mock_unique_constraint(name, column, deferrable: false)
+    double("UniqueConstraintDefinition",
+      name: name,
+      column: column,
+      deferrable: deferrable)
+  end
+
+  def mock_exclusion_constraint(name, expression, using: nil, where: nil, deferrable: false)
+    double("ExclusionConstraintDefinition",
+      name: name,
+      expression: expression,
+      using: using,
+      where: where,
+      deferrable: deferrable)
   end
 end


### PR DESCRIPTION
## Summary

Adds annotation support for two PostgreSQL constraint types that annotaterb has been overlooking: **unique constraints** and **exclusion constraints**. Also fixes a related leak where the indexes backing those constraints were showing up in the `Indexes` section.

## Motivation

In our application we lean on `DEFERRABLE INITIALLY DEFERRED` unique and exclusion constraints so we can swap values across rows within a transaction (e.g. reordering `position` on a list without hitting a mid-transaction uniqueness violation). This is a first-class PostgreSQL feature exposed by Rails 7.1+ as `add_unique_constraint ..., deferrable: :deferred` / `add_exclusion_constraint ..., deferrable: :deferred`, but none of it ever made it into annotaterb's output — the `deferrable` flag was dropped, and unique/exclusion constraints didn't have dedicated sections at all.

Worse, the underlying indexes were still enumerated: since PostgreSQL implements unique/exclusion constraints as indexes with the same name, `connection.indexes(table)` returns them, and annotaterb was rendering them as ordinary index rows. So a `deferrable` unique constraint appeared as a plain `UNIQUE` index with no hint of its actual semantics.

## Changes

1. **Two new annotation sections**, opt-in via config or CLI flags:
   - `show_unique_constraints` / `--show-unique-constraints`
   - `show_exclusion_constraints` / `--show-exclusion-constraints`

   Both mirror the existing check-constraint annotation pattern (default, markdown, yard, rdoc formats). The output includes column list / expression, `USING` method, `WHERE` predicate, and `DEFERRABLE INITIALLY IMMEDIATE|DEFERRED`.

2. **Filter constraint-backed indexes out of the `Indexes` section**, matching `ActiveRecord::SchemaDumper#indexes_in_create`: indexes whose name matches a unique or exclusion constraint name are excluded. Without this the same object would show up twice once you enable the new sections.

## Example output

```
#
# Indexes
#
#  index_reservations_on_room_id  (room_id)
#
# Unique Constraints
#
#  unique_position  (position) DEFERRABLE INITIALLY DEFERRED
#
# Exclusion Constraints
#
#  no_overlap       (room_id WITH =, during WITH &&) USING gist WHERE (canceled = false) DEFERRABLE INITIALLY DEFERRED
```

## Compatibility

- PostgreSQL-only feature; the accessors (`connection.unique_constraints`, `connection.exclusion_constraints`, `supports_*_constraints?`) exist in Rails 7.1+.
- Guarded with `respond_to?(:supports_*_constraints?)`, so on other adapters or older Rails versions the new sections silently do nothing and the index filter is a no-op — no risk of raising in projects that don't opt in.
- Both `show_unique_constraints` and `show_exclusion_constraints` default to `false`, so no existing annotations change unless the user opts in. The index-filtering change **does** apply unconditionally (matching Rails' schema dumper), so users of unique/exclusion constraints on Rails 7.1+ will see those rows disappear from `Indexes` — this is the desired behavior since it removes double reporting, and the info is preserved (and enriched) once the new sections are enabled.