### PR TITLE
Show DEFERRABLE INITIALLY on foreign keys

### DIFF
--- a/lib/annotate_rb/model_annotator/foreign_key_annotation/foreign_key_component_builder.rb
+++ b/lib/annotate_rb/model_annotator/foreign_key_annotation/foreign_key_component_builder.rb
@@ -32,6 +32,12 @@ module AnnotateRb
             constraints_info = ""
             constraints_info += "ON DELETE => #{foreign_key.on_delete} " if foreign_key.on_delete
             constraints_info += "ON UPDATE => #{foreign_key.on_update} " if foreign_key.on_update
+            if foreign_key.respond_to?(:deferrable) && foreign_key.deferrable
+              # Rails 7.0's extract_foreign_key_deferrable returns `true` for the initially-immediate case;
+              # 7.1+ normalized this to `:immediate`. Map `true` back to IMMEDIATE so we don't emit "INITIALLY TRUE".
+              initially = (foreign_key.deferrable == true) ? "IMMEDIATE" : foreign_key.deferrable.to_s.upcase
+              constraints_info += "DEFERRABLE INITIALLY #{initially} "
+            end
             constraints_info.strip
           end
         end

--- a/spec/lib/annotate_rb/model_annotator/foreign_key_annotation/annotation_builder_spec.rb
+++ b/spec/lib/annotate_rb/model_annotator/foreign_key_annotation/annotation_builder_spec.rb
@@ -122,6 +122,34 @@ RSpec.describe AnnotateRb::ModelAnnotator::ForeignKeyAnnotation::AnnotationBuild
       it { expect(default_format).to eq(expected_output) }
     end
 
+    context "with a deferrable foreign key" do
+      let(:foreign_keys) do
+        [
+          mock_foreign_key("fk_rails_immediate",
+            "immediate_thing_id",
+            "immediate_things",
+            "id",
+            deferrable: :immediate),
+          mock_foreign_key("fk_rails_deferred",
+            "deferred_thing_id",
+            "deferred_things",
+            "id",
+            deferrable: :deferred)
+        ]
+      end
+      let(:expected_output) do
+        <<~OUTPUT.strip
+          #
+          # Foreign Keys
+          #
+          #  fk_rails_deferred   (deferred_thing_id => deferred_things.id) DEFERRABLE INITIALLY DEFERRED
+          #  fk_rails_immediate  (immediate_thing_id => immediate_things.id) DEFERRABLE INITIALLY IMMEDIATE
+        OUTPUT
+      end
+
+      it { expect(default_format).to eq(expected_output) }
+    end
+
     context "with a composite foreign key" do
       let(:foreign_keys) do
         [

--- a/spec/support/annotate_test_helpers.rb
+++ b/spec/support/annotate_test_helpers.rb
@@ -35,7 +35,8 @@ module AnnotateTestHelpers
       to_table: to_table,
       primary_key: to_column,
       on_delete: constraints[:on_delete],
-      on_update: constraints[:on_update])
+      on_update: constraints[:on_update],
+      deferrable: constraints[:deferrable])
   end
 
   def mock_connection(indexes = [], foreign_keys = [], check_constraints = [], options = {})


### PR DESCRIPTION
## Summary

Emit `DEFERRABLE INITIALLY IMMEDIATE|DEFERRED` on foreign key annotations, alongside the existing `ON DELETE` / `ON UPDATE` metadata. Related to #364.

## Motivation

Rails exposes deferrable foreign keys via `ForeignKeyDefinition#deferrable`, but annotaterb was silently dropping the flag — a foreign key created with `add_foreign_key ..., deferrable: :deferred` was indistinguishable from a plain one in the annotation.

## Compatibility

Rails 7.0's `extract_foreign_key_deferrable` returns `true` for the initially-immediate case (7.1+ normalized this to `:immediate`); mapped `true` → `IMMEDIATE` for stable output. Guarded with `respond_to?(:deferrable)` for older Rails / other adapters.